### PR TITLE
Pre-public release enhancements

### DIFF
--- a/DragaliaAPI.Database.Test/DbTestFixture.cs
+++ b/DragaliaAPI.Database.Test/DbTestFixture.cs
@@ -1,4 +1,5 @@
-﻿using DragaliaAPI.Database.Repositories;
+﻿using DragaliaAPI.Database.Entities;
+using DragaliaAPI.Database.Repositories;
 using DragaliaAPI.Shared.Services;
 using Microsoft.EntityFrameworkCore;
 
@@ -22,7 +23,7 @@ public class DbTestFixture : IDisposable
             this.ApiContext,
             new CharaDataService()
         );
-        deviceAccountRepository.CreateNewSavefile("id");
+        deviceAccountRepository.CreateNewSavefile("id").Wait();
         deviceAccountRepository.SaveChangesAsync().Wait();
     }
 
@@ -39,6 +40,14 @@ public class DbTestFixture : IDisposable
     {
         if (data is null)
             return;
+
+        var ids = this.ApiContext.PlayerAbilityCrests.Select(x => x.AbilityCrestId).ToList();
+
+        if (typeof(TEntity) == typeof(DbAbilityCrest))
+        {
+            var ids2 = data.Cast<DbAbilityCrest>().Select(x => x.AbilityCrestId);
+            var offensive = ids.Intersect(ids2).ToList();
+        }
 
         await this.ApiContext.AddRangeAsync((IEnumerable<object>)data);
         await this.ApiContext.SaveChangesAsync();

--- a/DragaliaAPI.Database.Test/DbTestFixture.cs
+++ b/DragaliaAPI.Database.Test/DbTestFixture.cs
@@ -41,14 +41,6 @@ public class DbTestFixture : IDisposable
         if (data is null)
             return;
 
-        var ids = this.ApiContext.PlayerAbilityCrests.Select(x => x.AbilityCrestId).ToList();
-
-        if (typeof(TEntity) == typeof(DbAbilityCrest))
-        {
-            var ids2 = data.Cast<DbAbilityCrest>().Select(x => x.AbilityCrestId);
-            var offensive = ids.Intersect(ids2).ToList();
-        }
-
         await this.ApiContext.AddRangeAsync((IEnumerable<object>)data);
         await this.ApiContext.SaveChangesAsync();
     }

--- a/DragaliaAPI.Database.Test/Repositories/DeviceAccountRepositoryTest.cs
+++ b/DragaliaAPI.Database.Test/Repositories/DeviceAccountRepositoryTest.cs
@@ -6,6 +6,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace DragaliaAPI.Database.Test.Repositories;
 
+[Collection("RepositoryTest")]
 public class DeviceAccountRepositoryTest : IClassFixture<DbTestFixture>
 {
     private readonly DbTestFixture fixture;

--- a/DragaliaAPI.Database.Test/Repositories/PartyRepositoryTest.cs
+++ b/DragaliaAPI.Database.Test/Repositories/PartyRepositoryTest.cs
@@ -6,6 +6,7 @@ using static DragaliaAPI.Database.Test.DbTestFixture;
 
 namespace DragaliaAPI.Database.Test.Repositories;
 
+[Collection("RepositoryTest")]
 public class PartyRepositoryTest : IClassFixture<DbTestFixture>
 {
     private readonly DbTestFixture fixture;

--- a/DragaliaAPI.Database.Test/Repositories/QuestRepositoryTest.cs
+++ b/DragaliaAPI.Database.Test/Repositories/QuestRepositoryTest.cs
@@ -6,6 +6,7 @@ using static DragaliaAPI.Database.Test.DbTestFixture;
 
 namespace DragaliaAPI.Database.Test.Repositories;
 
+[Collection("RepositoryTest")]
 public class QuestRepositoryTest : IClassFixture<DbTestFixture>
 {
     private readonly DbTestFixture fixture;

--- a/DragaliaAPI.Database.Test/Repositories/SummonRepositoryTest.cs
+++ b/DragaliaAPI.Database.Test/Repositories/SummonRepositoryTest.cs
@@ -6,6 +6,7 @@ using static DragaliaAPI.Database.Test.DbTestFixture;
 
 namespace DragaliaAPI.Database.Test.Repositories;
 
+[Collection("RepositoryTest")]
 public class SummonRepositoryTest : IClassFixture<DbTestFixture>
 {
     private readonly DbTestFixture fixture;

--- a/DragaliaAPI.Database.Test/Repositories/UnitRepositoryTest.cs
+++ b/DragaliaAPI.Database.Test/Repositories/UnitRepositoryTest.cs
@@ -8,6 +8,7 @@ using static DragaliaAPI.Database.Test.DbTestFixture;
 
 namespace DragaliaAPI.Database.Test.Repositories;
 
+[Collection("RepositoryTest")]
 public class UnitRepositoryTest : IClassFixture<DbTestFixture>
 {
     private readonly DbTestFixture fixture;
@@ -188,14 +189,13 @@ public class UnitRepositoryTest : IClassFixture<DbTestFixture>
     public async Task AddDragons_UpdatesDatabase()
     {
         await fixture.AddToDatabase(
-            DbPlayerDragonDataFactory.Create(DeviceAccountId, Dragons.GalaRebornAgni)
+            DbPlayerDragonDataFactory.Create(DeviceAccountId, Dragons.KonohanaSakuya)
         );
         await fixture.AddToDatabase(
-            DbPlayerDragonReliabilityFactory.Create(DeviceAccountId, Dragons.GalaRebornAgni)
+            DbPlayerDragonReliabilityFactory.Create(DeviceAccountId, Dragons.KonohanaSakuya)
         );
 
-        List<Dragons> idList =
-            new() { Dragons.GalaRebornAgni, Dragons.GalaRebornZephyr, Dragons.GalaRebornZephyr };
+        List<Dragons> idList = new() { Dragons.KonohanaSakuya, Dragons.Michael, Dragons.Michael };
 
         await this.unitRepository.AddDragons(DeviceAccountId, idList);
         await this.unitRepository.SaveChangesAsync();
@@ -210,10 +210,10 @@ public class UnitRepositoryTest : IClassFixture<DbTestFixture>
             .Contain(
                 new List<Dragons>()
                 {
-                    Dragons.GalaRebornAgni,
-                    Dragons.GalaRebornAgni,
-                    Dragons.GalaRebornZephyr,
-                    Dragons.GalaRebornZephyr
+                    Dragons.KonohanaSakuya,
+                    Dragons.KonohanaSakuya,
+                    Dragons.Michael,
+                    Dragons.Michael
                 }
             );
 
@@ -224,7 +224,7 @@ public class UnitRepositoryTest : IClassFixture<DbTestFixture>
                 .ToListAsync()
         )
             .Should()
-            .Contain(new List<Dragons>() { Dragons.GalaRebornAgni, Dragons.GalaRebornZephyr, });
+            .Contain(new List<Dragons>() { Dragons.KonohanaSakuya, Dragons.Michael, });
     }
 
     [Fact]
@@ -270,7 +270,7 @@ public class UnitRepositoryTest : IClassFixture<DbTestFixture>
                 new()
                 {
                     DeviceAccountId = DeviceAccountId,
-                    AbilityCrestId = AbilityCrests.SweetSurprise
+                    AbilityCrestId = AbilityCrests.ADogsDay
                 },
                 new()
                 {
@@ -285,12 +285,12 @@ public class UnitRepositoryTest : IClassFixture<DbTestFixture>
                 new()
                 {
                     DeviceAccountId = DeviceAccountId,
-                    AbilityCrestId = AbilityCrests.SnipersAllure
+                    AbilityCrestId = AbilityCrests.TaikoTandem
                 },
                 new()
                 {
                     DeviceAccountId = DeviceAccountId,
-                    AbilityCrestId = AbilityCrests.DragonsNest
+                    AbilityCrestId = AbilityCrests.AChoiceBlend
                 },
                 new()
                 {
@@ -300,7 +300,7 @@ public class UnitRepositoryTest : IClassFixture<DbTestFixture>
                 new()
                 {
                     DeviceAccountId = DeviceAccountId,
-                    AbilityCrestId = AbilityCrests.TutelarysDestinyWolfsBoon
+                    AbilityCrestId = AbilityCrests.AKingsPrideSwordsBoon
                 }
             };
 
@@ -332,13 +332,13 @@ public class UnitRepositoryTest : IClassFixture<DbTestFixture>
                     EquipWeaponBodyId = WeaponBodies.Excalibur,
                     EquipDragonKeyId = 400,
                     EquipTalismanKeyId = 44444,
-                    EquipCrestSlotType1CrestId1 = AbilityCrests.SweetSurprise,
+                    EquipCrestSlotType1CrestId1 = AbilityCrests.ADogsDay,
                     EquipCrestSlotType1CrestId2 = AbilityCrests.TheRedImpulse,
                     EquipCrestSlotType1CrestId3 = AbilityCrests.ThePrinceofDragonyule,
-                    EquipCrestSlotType2CrestId1 = AbilityCrests.SnipersAllure,
-                    EquipCrestSlotType2CrestId2 = AbilityCrests.DragonsNest,
+                    EquipCrestSlotType2CrestId1 = AbilityCrests.TaikoTandem,
+                    EquipCrestSlotType2CrestId2 = AbilityCrests.AChoiceBlend,
                     EquipCrestSlotType3CrestId1 = AbilityCrests.CrownofLightSerpentsBoon,
-                    EquipCrestSlotType3CrestId2 = AbilityCrests.TutelarysDestinyWolfsBoon,
+                    EquipCrestSlotType3CrestId2 = AbilityCrests.AKingsPrideSwordsBoon,
                     EditSkill1CharaId = Charas.GalaMym,
                     EditSkill2CharaId = Charas.SummerCleo,
                 }

--- a/DragaliaAPI.Database.Test/Repositories/UserDataRepositoryTest.cs
+++ b/DragaliaAPI.Database.Test/Repositories/UserDataRepositoryTest.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace DragaliaAPI.Database.Test.Repositories;
 
+[Collection("RepositoryTest")]
 public class UserDataRepositoryTest : IClassFixture<DbTestFixture>
 {
     private readonly DbTestFixture fixture;

--- a/DragaliaAPI.Database/Repositories/DeviceAccountRepository.cs
+++ b/DragaliaAPI.Database/Repositories/DeviceAccountRepository.cs
@@ -52,6 +52,7 @@ public class DeviceAccountRepository : BaseRepository, IDeviceAccountRepository
         await this.AddDefaultWyrmprints(deviceAccountId);
         await this.AddDefaultDragons(deviceAccountId);
         await this.AddDefaultWeapons(deviceAccountId);
+        await this.AddDefaultMaterials(deviceAccountId);
     }
 
     private async Task AddDefaultParties(string deviceAccountId)
@@ -215,6 +216,21 @@ public class DeviceAccountRepository : BaseRepository, IDeviceAccountRepository
         );
     }
 
+    private async Task AddDefaultMaterials(string deviceAccountId, int defaultQuantity = 10000)
+    {
+        await this.apiContext.PlayerStorage.AddRangeAsync(
+            DefaultSavefileData.UpgradeMaterials.Select(
+                x =>
+                    new DbPlayerMaterial()
+                    {
+                        DeviceAccountId = deviceAccountId,
+                        MaterialId = x,
+                        Quantity = defaultQuantity
+                    }
+            )
+        );
+    }
+
     private static class DefaultSavefileData
     {
         public static readonly IReadOnlyList<AbilityCrests> FiveStarCrests =
@@ -355,6 +371,13 @@ public class DeviceAccountRepository : BaseRepository, IDeviceAccountRepository
             WeaponBodies.UmbralChaser,
             WeaponBodies.ConsumingDarkness,
             WeaponBodies.DuskTrigger
+        };
+
+        public static readonly IReadOnlyList<Materials> UpgradeMaterials = new List<Materials>()
+        {
+            Materials.GoldCrystal,
+            Materials.SilverCrystal,
+            Materials.BronzeCrystal
         };
     }
 }

--- a/DragaliaAPI.Database/Repositories/DeviceAccountRepository.cs
+++ b/DragaliaAPI.Database/Repositories/DeviceAccountRepository.cs
@@ -83,16 +83,206 @@ public class DeviceAccountRepository : BaseRepository, IDeviceAccountRepository
             }
         );
 
-        await apiContext.PlayerAbilityCrests.AddAsync(
-            new DbAbilityCrest()
-            {
-                DeviceAccountId = deviceAccountId,
-                AbilityCrestId = AbilityCrests.ValiantCrown,
-                BuildupCount = 50,
-                LimitBreakCount = 4,
-                GetTime = DateTime.UtcNow,
-                IsNew = false
-            }
+        await this.AddDefaultWyrmprints(deviceAccountId);
+
+        await this.AddDefaultDragons(deviceAccountId);
+    }
+
+    private async Task AddDefaultDragons(string deviceAccountId)
+    {
+        await this.apiContext.PlayerDragonData.AddRangeAsync(
+            Enumerable
+                .Repeat(
+                    defaultDragons.Select(
+                        x =>
+                            new DbPlayerDragonData()
+                            {
+                                DeviceAccountId = deviceAccountId,
+                                DragonId = x,
+                                Level = 100,
+                                LimitBreakCount = 4,
+                                Ability1Level = 5,
+                                Ability2Level = 5,
+                                Skill1Level = 2,
+                                AttackPlusCount = 50,
+                                HpPlusCount = 50,
+                                Exp = 1_240_020,
+                                GetTime = DateTime.UtcNow,
+                                IsLock = false,
+                                IsNew = false,
+                            }
+                    ),
+                    4
+                )
+                .SelectMany(x => x)
+        );
+
+        await this.apiContext.PlayerDragonReliability.AddRangeAsync(
+            defaultDragons.Select(x => DbPlayerDragonReliabilityFactory.Create(deviceAccountId, x))
         );
     }
+
+    private async Task AddDefaultWyrmprints(string deviceAccountId)
+    {
+        await this.apiContext.PlayerAbilityCrests.AddRangeAsync(
+            default5StarCrests
+                .Select(
+                    x =>
+                        new DbAbilityCrest()
+                        {
+                            AbilityCrestId = x,
+                            BuildupCount = 50,
+                            LimitBreakCount = 4,
+                            DeviceAccountId = deviceAccountId,
+                            AttackPlusCount = 50,
+                            HpPlusCount = 50,
+                            EquipableCount = 4,
+                            GetTime = DateTime.UtcNow,
+                            IsFavorite = false,
+                            IsNew = false,
+                        }
+                )
+                .Concat(
+                    default4StarCrests.Select(
+                        x =>
+                            new DbAbilityCrest()
+                            {
+                                AbilityCrestId = x,
+                                BuildupCount = 40,
+                                LimitBreakCount = 4,
+                                DeviceAccountId = deviceAccountId,
+                                AttackPlusCount = 50,
+                                HpPlusCount = 50,
+                                EquipableCount = 4,
+                                GetTime = DateTime.UtcNow,
+                                IsFavorite = false,
+                                IsNew = false,
+                            }
+                    )
+                )
+                .Concat(
+                    default3StarCrests.Select(
+                        x =>
+                            new DbAbilityCrest()
+                            {
+                                AbilityCrestId = x,
+                                BuildupCount = 10,
+                                LimitBreakCount = 4,
+                                DeviceAccountId = deviceAccountId,
+                                AttackPlusCount = 50,
+                                HpPlusCount = 50,
+                                EquipableCount = 4,
+                                GetTime = DateTime.UtcNow,
+                                IsFavorite = false,
+                                IsNew = false,
+                            }
+                    )
+                )
+                .Concat(
+                    defaultSinDomCrests.Select(
+                        x =>
+                            new DbAbilityCrest()
+                            {
+                                AbilityCrestId = x,
+                                BuildupCount = 30,
+                                LimitBreakCount = 4,
+                                DeviceAccountId = deviceAccountId,
+                                AttackPlusCount = 40,
+                                HpPlusCount = 40,
+                                EquipableCount = 4,
+                                GetTime = DateTime.UtcNow,
+                                IsFavorite = false,
+                                IsNew = false,
+                            }
+                    )
+                )
+        );
+    }
+
+    private static readonly IReadOnlyList<AbilityCrests> default5StarCrests =
+        new List<AbilityCrests>()
+        {
+            // Generic SD
+            AbilityCrests.ValiantCrown,
+            AbilityCrests.HeraldsofHinomoto,
+            // Generic strength
+            AbilityCrests.PecorinesGrandAdventure,
+            AbilityCrests.PrimalCrisis,
+            AbilityCrests.MemoryofaFriend,
+            // FS
+            AbilityCrests.HereCometheSealers,
+            // Generic crit
+            AbilityCrests.ThirdAnniversary,
+            AbilityCrests.LevinsChampion,
+            // Punishers
+            AbilityCrests.MeandMyBestie, // Burn
+            AbilityCrests.IntheLimelight, // Scorchrend
+            AbilityCrests.WingsofRebellionatRest, // Frostbite
+            AbilityCrests.AManUnchanging, // Poison
+            AbilityCrests.SweetSurprise, // Scorchrend
+            AbilityCrests.SpiritoftheSeason, // Paralysis
+            AbilityCrests.ExtremeTeamwork, // Flashburn
+            AbilityCrests.WelcometotheOpera, // Shadowblight
+            // Support
+            AbilityCrests.JewelsoftheSun,
+            AbilityCrests.StudyRabbits,
+            AbilityCrests.GiveMeYourWounded,
+            AbilityCrests.ProperMaintenance,
+            AbilityCrests.CastleCheerCorps,
+            // Misc
+            AbilityCrests.TheChocolatiers,
+            AbilityCrests.WorthyRivals,
+            AbilityCrests.AnAncientOath,
+        };
+
+    private static readonly IReadOnlyList<AbilityCrests> default4StarCrests =
+        new List<AbilityCrests>()
+        {
+            // Punishers
+            AbilityCrests.ThePlaguebringer,
+            AbilityCrests.HisCleverBrother,
+            AbilityCrests.AButlersSmile,
+            AbilityCrests.TheNoblesDayOff,
+            // Misc
+            AbilityCrests.FromWhenceHeComes,
+            AbilityCrests.SnipersAllure,
+            AbilityCrests.LunarFestivities,
+            AbilityCrests.BeautifulNothingness,
+        };
+
+    private static readonly IReadOnlyList<AbilityCrests> default3StarCrests =
+        new List<AbilityCrests>()
+        {
+            AbilityCrests.Bellathorna,
+            AbilityCrests.DragonArcanum,
+            AbilityCrests.DragonsNest
+        };
+
+    private static readonly IReadOnlyList<AbilityCrests> defaultSinDomCrests =
+        new List<AbilityCrests>()
+        {
+            // SD
+            AbilityCrests.TutelarysDestinyWolfsBoon,
+            AbilityCrests.AppleliciousDreamsButterflysBoon,
+            AbilityCrests.AnUnfreezingFlowerDeersBoon,
+            AbilityCrests.AKnightsDreamAxesBoon,
+            // Psalm
+            AbilityCrests.PromisedPietyStaffsBoon,
+            AbilityCrests.RavenousFireCrownsBoon,
+            AbilityCrests.MaskofDeterminationBowsBoon
+        };
+
+    private static readonly IReadOnlyList<Dragons> defaultDragons = new List<Dragons>()
+    {
+        Dragons.GalaRebornAgni,
+        Dragons.Horus,
+        Dragons.GalaRebornPoseidon,
+        Dragons.GaibhneCreidhne,
+        Dragons.GalaRebornZephyr,
+        Dragons.Freyja,
+        Dragons.GalaRebornJeanne,
+        Dragons.TieShanGongzhu,
+        Dragons.GalaRebornNidhogg,
+        Dragons.Azazel
+    };
 }

--- a/DragaliaAPI.Database/Repositories/DeviceAccountRepository.cs
+++ b/DragaliaAPI.Database/Repositories/DeviceAccountRepository.cs
@@ -33,7 +33,7 @@ public class DeviceAccountRepository : BaseRepository, IDeviceAccountRepository
         return await apiContext.DeviceAccounts.SingleOrDefaultAsync(x => x.Id == id);
     }
 
-    public async Task CreateNewSavefile(string deviceAccountId)
+    public async Task CreateNewSavefileBase(string deviceAccountId)
     {
         DbPlayerUserData userData = DbSavefileUserDataFactory.Create(deviceAccountId);
 #if DEBUG
@@ -49,6 +49,12 @@ public class DeviceAccountRepository : BaseRepository, IDeviceAccountRepository
         );
 
         await this.AddDefaultParties(deviceAccountId);
+    }
+
+    public async Task CreateNewSavefile(string deviceAccountId)
+    {
+        await this.CreateNewSavefileBase(deviceAccountId);
+
         await this.AddDefaultWyrmprints(deviceAccountId);
         await this.AddDefaultDragons(deviceAccountId);
         await this.AddDefaultWeapons(deviceAccountId);

--- a/DragaliaAPI.Database/Repositories/DeviceAccountRepository.cs
+++ b/DragaliaAPI.Database/Repositories/DeviceAccountRepository.cs
@@ -48,44 +48,111 @@ public class DeviceAccountRepository : BaseRepository, IDeviceAccountRepository
             )
         );
 
-        List<DbParty> defaultParties = new();
-        for (int i = 1; i <= PartySlotCount; i++)
-        {
-            defaultParties.Add(
-                new()
-                {
-                    DeviceAccountId = deviceAccountId,
-                    PartyName = "Default",
-                    PartyNo = i,
-                    Units = new List<DbPartyUnit>()
-                    {
-                        new() { UnitNo = 1, CharaId = Charas.ThePrince },
-                        new() { UnitNo = 2, CharaId = Charas.Empty },
-                        new() { UnitNo = 3, CharaId = Charas.Empty },
-                        new() { UnitNo = 4, CharaId = Charas.Empty }
-                    }
-                }
-            );
-        }
-
-        await apiContext.PlayerParties.AddRangeAsync(defaultParties);
-
-        await apiContext.PlayerWeapons.AddAsync(
-            new DbWeaponBody()
-            {
-                DeviceAccountId = deviceAccountId,
-                WeaponBodyId = WeaponBodies.PrimalCrimson,
-                BuildupCount = 80,
-                LimitBreakCount = 8,
-                LimitOverCount = 1,
-                IsNew = false,
-                GetTime = DateTime.UtcNow,
-            }
-        );
-
+        await this.AddDefaultParties(deviceAccountId);
         await this.AddDefaultWyrmprints(deviceAccountId);
-
         await this.AddDefaultDragons(deviceAccountId);
+        await this.AddDefaultWeapons(deviceAccountId);
+    }
+
+    private async Task AddDefaultParties(string deviceAccountId)
+    {
+        await this.apiContext.PlayerParties.AddRangeAsync(
+            Enumerable
+                .Range(1, PartySlotCount)
+                .Select(
+                    x =>
+                        new DbParty()
+                        {
+                            DeviceAccountId = deviceAccountId,
+                            PartyName = "Default",
+                            PartyNo = x,
+                            Units = new List<DbPartyUnit>()
+                            {
+                                new() { UnitNo = 1, CharaId = Charas.ThePrince },
+                                new() { UnitNo = 2, CharaId = Charas.Empty },
+                                new() { UnitNo = 3, CharaId = Charas.Empty },
+                                new() { UnitNo = 4, CharaId = Charas.Empty }
+                            }
+                        }
+                )
+        );
+    }
+
+    private async Task AddDefaultWyrmprints(string deviceAccountId)
+    {
+        await this.apiContext.PlayerAbilityCrests.AddRangeAsync(
+            DefaultSavefileData.FiveStarCrests
+                .Select(
+                    x =>
+                        new DbAbilityCrest()
+                        {
+                            AbilityCrestId = x,
+                            BuildupCount = 50,
+                            LimitBreakCount = 4,
+                            DeviceAccountId = deviceAccountId,
+                            AttackPlusCount = 50,
+                            HpPlusCount = 50,
+                            EquipableCount = 4,
+                            GetTime = DateTime.UtcNow,
+                            IsFavorite = false,
+                            IsNew = false,
+                        }
+                )
+                .Concat(
+                    DefaultSavefileData.FourStarCrests.Select(
+                        x =>
+                            new DbAbilityCrest()
+                            {
+                                AbilityCrestId = x,
+                                BuildupCount = 40,
+                                LimitBreakCount = 4,
+                                DeviceAccountId = deviceAccountId,
+                                AttackPlusCount = 50,
+                                HpPlusCount = 50,
+                                EquipableCount = 4,
+                                GetTime = DateTime.UtcNow,
+                                IsFavorite = false,
+                                IsNew = false,
+                            }
+                    )
+                )
+                .Concat(
+                    DefaultSavefileData.ThreeStarCrests.Select(
+                        x =>
+                            new DbAbilityCrest()
+                            {
+                                AbilityCrestId = x,
+                                BuildupCount = 10,
+                                LimitBreakCount = 4,
+                                DeviceAccountId = deviceAccountId,
+                                AttackPlusCount = 50,
+                                HpPlusCount = 50,
+                                EquipableCount = 4,
+                                GetTime = DateTime.UtcNow,
+                                IsFavorite = false,
+                                IsNew = false,
+                            }
+                    )
+                )
+                .Concat(
+                    DefaultSavefileData.SinDomCrests.Select(
+                        x =>
+                            new DbAbilityCrest()
+                            {
+                                AbilityCrestId = x,
+                                BuildupCount = 30,
+                                LimitBreakCount = 4,
+                                DeviceAccountId = deviceAccountId,
+                                AttackPlusCount = 40,
+                                HpPlusCount = 40,
+                                EquipableCount = 4,
+                                GetTime = DateTime.UtcNow,
+                                IsFavorite = false,
+                                IsNew = false,
+                            }
+                    )
+                )
+        );
     }
 
     private async Task AddDefaultDragons(string deviceAccountId)
@@ -93,7 +160,7 @@ public class DeviceAccountRepository : BaseRepository, IDeviceAccountRepository
         await this.apiContext.PlayerDragonData.AddRangeAsync(
             Enumerable
                 .Repeat(
-                    defaultDragons.Select(
+                    DefaultSavefileData.Dragons.Select(
                         x =>
                             new DbPlayerDragonData()
                             {
@@ -118,148 +185,97 @@ public class DeviceAccountRepository : BaseRepository, IDeviceAccountRepository
         );
 
         await this.apiContext.PlayerDragonReliability.AddRangeAsync(
-            defaultDragons.Select(x => DbPlayerDragonReliabilityFactory.Create(deviceAccountId, x))
+            DefaultDragons.Select(x => DbPlayerDragonReliabilityFactory.Create(deviceAccountId, x))
         );
     }
 
-    private async Task AddDefaultWyrmprints(string deviceAccountId)
+    private async Task AddDefaultWeapons(string deviceAccountId)
     {
-        await this.apiContext.PlayerAbilityCrests.AddRangeAsync(
-            default5StarCrests
-                .Select(
-                    x =>
-                        new DbAbilityCrest()
-                        {
-                            AbilityCrestId = x,
-                            BuildupCount = 50,
-                            LimitBreakCount = 4,
-                            DeviceAccountId = deviceAccountId,
-                            AttackPlusCount = 50,
-                            HpPlusCount = 50,
-                            EquipableCount = 4,
-                            GetTime = DateTime.UtcNow,
-                            IsFavorite = false,
-                            IsNew = false,
-                        }
-                )
-                .Concat(
-                    default4StarCrests.Select(
-                        x =>
-                            new DbAbilityCrest()
-                            {
-                                AbilityCrestId = x,
-                                BuildupCount = 40,
-                                LimitBreakCount = 4,
-                                DeviceAccountId = deviceAccountId,
-                                AttackPlusCount = 50,
-                                HpPlusCount = 50,
-                                EquipableCount = 4,
-                                GetTime = DateTime.UtcNow,
-                                IsFavorite = false,
-                                IsNew = false,
-                            }
-                    )
-                )
-                .Concat(
-                    default3StarCrests.Select(
-                        x =>
-                            new DbAbilityCrest()
-                            {
-                                AbilityCrestId = x,
-                                BuildupCount = 10,
-                                LimitBreakCount = 4,
-                                DeviceAccountId = deviceAccountId,
-                                AttackPlusCount = 50,
-                                HpPlusCount = 50,
-                                EquipableCount = 4,
-                                GetTime = DateTime.UtcNow,
-                                IsFavorite = false,
-                                IsNew = false,
-                            }
-                    )
-                )
-                .Concat(
-                    defaultSinDomCrests.Select(
-                        x =>
-                            new DbAbilityCrest()
-                            {
-                                AbilityCrestId = x,
-                                BuildupCount = 30,
-                                LimitBreakCount = 4,
-                                DeviceAccountId = deviceAccountId,
-                                AttackPlusCount = 40,
-                                HpPlusCount = 40,
-                                EquipableCount = 4,
-                                GetTime = DateTime.UtcNow,
-                                IsFavorite = false,
-                                IsNew = false,
-                            }
-                    )
-                )
+        await this.apiContext.PlayerWeapons.AddRangeAsync(
+            DefaultSavefileData.WeaponBodies.Select(
+                x =>
+                    new DbWeaponBody()
+                    {
+                        DeviceAccountId = deviceAccountId,
+                        WeaponBodyId = x,
+                        BuildupCount = 80,
+                        LimitBreakCount = 8,
+                        LimitOverCount = 1,
+                        EquipableCount = 4,
+                        AdditionalCrestSlotType1Count = 1,
+                        AdditionalCrestSlotType2Count = 0,
+                        AdditionalCrestSlotType3Count = 2,
+                        FortPassiveCharaWeaponBuildupCount = 1,
+                        IsNew = true,
+                        GetTime = DateTime.UtcNow,
+                    }
+            )
         );
     }
 
-    private static readonly IReadOnlyList<AbilityCrests> default5StarCrests =
-        new List<AbilityCrests>()
-        {
-            // Generic SD
-            AbilityCrests.ValiantCrown,
-            AbilityCrests.HeraldsofHinomoto,
-            // Generic strength
-            AbilityCrests.PecorinesGrandAdventure,
-            AbilityCrests.PrimalCrisis,
-            AbilityCrests.MemoryofaFriend,
-            // FS
-            AbilityCrests.HereCometheSealers,
-            // Generic crit
-            AbilityCrests.ThirdAnniversary,
-            AbilityCrests.LevinsChampion,
-            // Punishers
-            AbilityCrests.MeandMyBestie, // Burn
-            AbilityCrests.IntheLimelight, // Scorchrend
-            AbilityCrests.WingsofRebellionatRest, // Frostbite
-            AbilityCrests.AManUnchanging, // Poison
-            AbilityCrests.SweetSurprise, // Scorchrend
-            AbilityCrests.SpiritoftheSeason, // Paralysis
-            AbilityCrests.ExtremeTeamwork, // Flashburn
-            AbilityCrests.WelcometotheOpera, // Shadowblight
-            // Support
-            AbilityCrests.JewelsoftheSun,
-            AbilityCrests.StudyRabbits,
-            AbilityCrests.GiveMeYourWounded,
-            AbilityCrests.ProperMaintenance,
-            AbilityCrests.CastleCheerCorps,
-            // Misc
-            AbilityCrests.TheChocolatiers,
-            AbilityCrests.WorthyRivals,
-            AbilityCrests.AnAncientOath,
-        };
+    private static class DefaultSavefileData
+    {
+        public static readonly IReadOnlyList<AbilityCrests> FiveStarCrests =
+            new List<AbilityCrests>()
+            {
+                // Generic SD
+                AbilityCrests.ValiantCrown,
+                AbilityCrests.HeraldsofHinomoto,
+                // Generic strength
+                AbilityCrests.PecorinesGrandAdventure,
+                AbilityCrests.PrimalCrisis,
+                AbilityCrests.MemoryofaFriend,
+                // FS
+                AbilityCrests.HereCometheSealers,
+                // Generic crit
+                AbilityCrests.ThirdAnniversary,
+                AbilityCrests.LevinsChampion,
+                // Punishers
+                AbilityCrests.MeandMyBestie, // Burn
+                AbilityCrests.IntheLimelight, // Scorchrend
+                AbilityCrests.WingsofRebellionatRest, // Frostbite
+                AbilityCrests.AManUnchanging, // Poison
+                AbilityCrests.SweetSurprise, // Scorchrend
+                AbilityCrests.SpiritoftheSeason, // Paralysis
+                AbilityCrests.ExtremeTeamwork, // Flashburn
+                AbilityCrests.WelcometotheOpera, // Shadowblight
+                // Support
+                AbilityCrests.JewelsoftheSun,
+                AbilityCrests.StudyRabbits,
+                AbilityCrests.GiveMeYourWounded,
+                AbilityCrests.ProperMaintenance,
+                AbilityCrests.CastleCheerCorps,
+                // Misc
+                AbilityCrests.TheChocolatiers,
+                AbilityCrests.WorthyRivals,
+                AbilityCrests.AnAncientOath,
+            };
 
-    private static readonly IReadOnlyList<AbilityCrests> default4StarCrests =
-        new List<AbilityCrests>()
-        {
-            // Punishers
-            AbilityCrests.ThePlaguebringer,
-            AbilityCrests.HisCleverBrother,
-            AbilityCrests.AButlersSmile,
-            AbilityCrests.TheNoblesDayOff,
-            // Misc
-            AbilityCrests.FromWhenceHeComes,
-            AbilityCrests.SnipersAllure,
-            AbilityCrests.LunarFestivities,
-            AbilityCrests.BeautifulNothingness,
-        };
+        public static readonly IReadOnlyList<AbilityCrests> FourStarCrests =
+            new List<AbilityCrests>()
+            {
+                // Punishers
+                AbilityCrests.ThePlaguebringer,
+                AbilityCrests.HisCleverBrother,
+                AbilityCrests.AButlersSmile,
+                AbilityCrests.TheNoblesDayOff,
+                // Misc
+                AbilityCrests.FromWhenceHeComes,
+                AbilityCrests.SnipersAllure,
+                AbilityCrests.LunarFestivities,
+                AbilityCrests.BeautifulNothingness,
+            };
 
-    private static readonly IReadOnlyList<AbilityCrests> default3StarCrests =
-        new List<AbilityCrests>()
-        {
-            AbilityCrests.Bellathorna,
-            AbilityCrests.DragonArcanum,
-            AbilityCrests.DragonsNest
-        };
+        public static readonly IReadOnlyList<AbilityCrests> ThreeStarCrests =
+            new List<AbilityCrests>()
+            {
+                AbilityCrests.Bellathorna,
+                // Technically Dragon Arcanum is 2 star but whatever
+                AbilityCrests.DragonArcanum,
+                AbilityCrests.DragonsNest
+            };
 
-    private static readonly IReadOnlyList<AbilityCrests> defaultSinDomCrests =
-        new List<AbilityCrests>()
+        public static readonly IReadOnlyList<AbilityCrests> SinDomCrests = new List<AbilityCrests>()
         {
             // SD
             AbilityCrests.TutelarysDestinyWolfsBoon,
@@ -272,17 +288,71 @@ public class DeviceAccountRepository : BaseRepository, IDeviceAccountRepository
             AbilityCrests.MaskofDeterminationBowsBoon
         };
 
-    private static readonly IReadOnlyList<Dragons> defaultDragons = new List<Dragons>()
-    {
-        Dragons.GalaRebornAgni,
-        Dragons.Horus,
-        Dragons.GalaRebornPoseidon,
-        Dragons.GaibhneCreidhne,
-        Dragons.GalaRebornZephyr,
-        Dragons.Freyja,
-        Dragons.GalaRebornJeanne,
-        Dragons.TieShanGongzhu,
-        Dragons.GalaRebornNidhogg,
-        Dragons.Azazel
-    };
+        public static readonly IReadOnlyList<Dragons> Dragons = new List<Dragons>()
+        {
+            Shared.Definitions.Enums.Dragons.GalaRebornAgni,
+            Shared.Definitions.Enums.Dragons.Horus,
+            Shared.Definitions.Enums.Dragons.GalaRebornPoseidon,
+            Shared.Definitions.Enums.Dragons.GaibhneCreidhne,
+            Shared.Definitions.Enums.Dragons.GalaRebornZephyr,
+            Shared.Definitions.Enums.Dragons.Freyja,
+            Shared.Definitions.Enums.Dragons.GalaRebornJeanne,
+            Shared.Definitions.Enums.Dragons.TieShanGongzhu,
+            Shared.Definitions.Enums.Dragons.GalaRebornNidhogg,
+            Shared.Definitions.Enums.Dragons.Azazel
+        };
+
+        public static readonly IReadOnlyList<WeaponBodies> Weapons = new List<WeaponBodies>()
+        {
+            // Flame
+            WeaponBodies.PrimalCrimson,
+            WeaponBodies.RagingConflagration,
+            WeaponBodies.FlamerulersFang,
+            WeaponBodies.NobleCrimsonHeat,
+            WeaponBodies.OmniflameLance,
+            WeaponBodies.ValkyriesHellfire,
+            WeaponBodies.Hellblaze,
+            WeaponBodies.Flamerollick,
+            WeaponBodies.BigBangTrigger,
+            // Water
+            WeaponBodies.PrimalAqua,
+            WeaponBodies.CalamitousTorrent,
+            WeaponBodies.TiderulersFang,
+            WeaponBodies.LimpidCascade,
+            WeaponBodies.SapphireMercurius,
+            WeaponBodies.AqueousPrison,
+            WeaponBodies.RuleroftheJeweledTide,
+            WeaponBodies.AquamarineTrigger,
+            // Wind
+            WeaponBodies.PrimalTempest,
+            WeaponBodies.NobleHorizon,
+            WeaponBodies.WindrulersFang,
+            WeaponBodies.TempestsGuide,
+            WeaponBodies.GalesAid,
+            WeaponBodies.JormungandsWrath,
+            WeaponBodies.StormChaser,
+            WeaponBodies.Squallruler,
+            WeaponBodies.CycloneTrigger,
+            // Light
+            WeaponBodies.PrimalLightning,
+            WeaponBodies.DauntingFlash,
+            WeaponBodies.FulminatorsFang,
+            WeaponBodies.IndomitableThundercrash,
+            WeaponBodies.RadiantLightflash,
+            WeaponBodies.JupitersShimmer,
+            WeaponBodies.ElectronBurst,
+            WeaponBodies.CosmicRuler,
+            WeaponBodies.DivineTrigger,
+            // Shadow
+            WeaponBodies.PrimalHex,
+            WeaponBodies.EternalAbyss,
+            WeaponBodies.ShaderulersFang,
+            WeaponBodies.NightfallsDarkbiteAxe,
+            WeaponBodies.EbonPlagueLance,
+            WeaponBodies.NightmareProphecy,
+            WeaponBodies.UmbralChaser,
+            WeaponBodies.ConsumingDarkness,
+            WeaponBodies.DuskTrigger
+        };
+    }
 }

--- a/DragaliaAPI.Database/Repositories/DeviceAccountRepository.cs
+++ b/DragaliaAPI.Database/Repositories/DeviceAccountRepository.cs
@@ -185,14 +185,16 @@ public class DeviceAccountRepository : BaseRepository, IDeviceAccountRepository
         );
 
         await this.apiContext.PlayerDragonReliability.AddRangeAsync(
-            DefaultDragons.Select(x => DbPlayerDragonReliabilityFactory.Create(deviceAccountId, x))
+            DefaultSavefileData.Dragons.Select(
+                x => DbPlayerDragonReliabilityFactory.Create(deviceAccountId, x)
+            )
         );
     }
 
     private async Task AddDefaultWeapons(string deviceAccountId)
     {
         await this.apiContext.PlayerWeapons.AddRangeAsync(
-            DefaultSavefileData.WeaponBodies.Select(
+            DefaultSavefileData.Weapons.Select(
                 x =>
                     new DbWeaponBody()
                     {

--- a/DragaliaAPI.Database/Repositories/IDeviceAccountRepository.cs
+++ b/DragaliaAPI.Database/Repositories/IDeviceAccountRepository.cs
@@ -9,4 +9,5 @@ public interface IDeviceAccountRepository : IBaseRepository
     Task<DbDeviceAccount?> GetDeviceAccountById(string id);
 
     Task CreateNewSavefile(string deviceAccountId);
+    Task CreateNewSavefileBase(string deviceAccountId);
 }

--- a/DragaliaAPI.Database/Repositories/IInventoryRepository.cs
+++ b/DragaliaAPI.Database/Repositories/IInventoryRepository.cs
@@ -11,4 +11,5 @@ public interface IInventoryRepository : IBaseRepository
     DbPlayerMaterial AddMaterial(string deviceAccountId, Materials type);
     Task<DbPlayerMaterial?> GetMaterial(string deviceAccountId, Materials materialId);
     IQueryable<DbPlayerMaterial> GetMaterials(string deviceAccountId);
+    Task AddMaterials(string deviceAccountId, IEnumerable<Materials> list, int quantity);
 }

--- a/DragaliaAPI.Database/Repositories/InventoryRepository.cs
+++ b/DragaliaAPI.Database/Repositories/InventoryRepository.cs
@@ -55,6 +55,32 @@ public class InventoryRepository : BaseRepository, IInventoryRepository
             .Entity;
     }
 
+    public async Task AddMaterials(
+        string deviceAccountId,
+        IEnumerable<Materials> list,
+        int quantity
+    )
+    {
+        foreach (Materials m in list)
+        {
+            // Db query (find) in loop??? Any way to do this better???
+            DbPlayerMaterial material =
+                await this.apiContext.PlayerStorage.FindAsync(deviceAccountId, m)
+                ?? (
+                    await this.apiContext.AddAsync(
+                        new DbPlayerMaterial()
+                        {
+                            DeviceAccountId = deviceAccountId,
+                            MaterialId = m,
+                            Quantity = 0
+                        }
+                    )
+                ).Entity;
+
+            material.Quantity += quantity;
+        }
+    }
+
     public async Task<DbPlayerMaterial?> GetMaterial(string deviceAccountId, Materials materialId)
     {
         return await this.apiContext.PlayerStorage.FirstOrDefaultAsync(

--- a/DragaliaAPI.Test/Integration/IntegrationTestFixture.cs
+++ b/DragaliaAPI.Test/Integration/IntegrationTestFixture.cs
@@ -104,8 +104,8 @@ public class IntegrationTestFixture : CustomWebApplicationFactory<Program>
             }
         );
 
-        repository.CreateNewSavefile(PreparedDeviceAccountId);
-        repository.CreateNewSavefile(DeviceAccountId);
+        repository.CreateNewSavefileBase(PreparedDeviceAccountId).Wait();
+        repository.CreateNewSavefileBase(DeviceAccountId).Wait();
         PopulateAllMaterials().Wait();
         context.SaveChanges();
     }

--- a/DragaliaAPI.Test/Integration/Other/DeleteSavefileTest.cs
+++ b/DragaliaAPI.Test/Integration/Other/DeleteSavefileTest.cs
@@ -61,8 +61,9 @@ public class DeleteSavefileTest : IClassFixture<IntegrationTestFixture>
             .ContainSingle()
             .And.AllSatisfy(x => x.chara_id.Should().Be(Charas.ThePrince));
         storedSavefile.material_list.Should().BeEmpty();
-        storedSavefile.dragon_list.Should().BeEmpty();
-        storedSavefile.dragon_reliability_list.Should().BeEmpty();
+        // Not so due to the default dragons being given
+        // storedSavefile.dragon_list.Should().BeEmpty();
+        // storedSavefile.dragon_reliability_list.Should().BeEmpty();
         storedSavefile.quest_story_list.Should().BeEmpty();
         storedSavefile.castle_story_list.Should().BeEmpty();
     }

--- a/DragaliaAPI.Test/Integration/Other/DeleteSavefileTest.cs
+++ b/DragaliaAPI.Test/Integration/Other/DeleteSavefileTest.cs
@@ -60,8 +60,8 @@ public class DeleteSavefileTest : IClassFixture<IntegrationTestFixture>
             .Should()
             .ContainSingle()
             .And.AllSatisfy(x => x.chara_id.Should().Be(Charas.ThePrince));
-        storedSavefile.material_list.Should().BeEmpty();
-        // Not so due to the default dragons being given
+        // Not so due to the default data being given
+        // storedSavefile.material_list.Should().BeEmpty();
         // storedSavefile.dragon_list.Should().BeEmpty();
         // storedSavefile.dragon_reliability_list.Should().BeEmpty();
         storedSavefile.quest_story_list.Should().BeEmpty();

--- a/DragaliaAPI.sln
+++ b/DragaliaAPI.sln
@@ -11,6 +11,7 @@ Project("{E53339B2-1760-4266-BCC7-CA923CBCF16C}") = "docker-compose", "docker-co
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{BC72B633-A158-4169-9B47-3CB9C689A57E}"
 	ProjectSection(SolutionItems) = preProject
+		.env = .env
 		.env.default = .env.default
 		.gitignore = .gitignore
 		.github\workflows\build.yml = .github\workflows\build.yml

--- a/DragaliaAPI/Controllers/Dragalia/DungeonRecordController.cs
+++ b/DragaliaAPI/Controllers/Dragalia/DungeonRecordController.cs
@@ -7,7 +7,6 @@ using DragaliaAPI.Services;
 using DragaliaAPI.Shared.Definitions.Enums;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
-using NuGet.Packaging.Signing;
 
 namespace DragaliaAPI.Controllers.Dragalia;
 
@@ -53,7 +52,7 @@ public class DungeonRecordController : DragaliaControllerBase
         userData.Crystal += 25;
 
         IEnumerable<Materials> drops = DefaultDrops.GetRandomList();
-        await this.inventoryRepository.AddMaterials(this.DeviceAccountId, drops, 10);
+        await this.inventoryRepository.AddMaterials(this.DeviceAccountId, drops, 100);
 
         UpdateDataList updateDataList = this.updateDataService.GetUpdateDataList(
             this.DeviceAccountId
@@ -177,131 +176,9 @@ public class DungeonRecordController : DragaliaControllerBase
     }
 
     [HttpPost("record_multi")]
-    public async Task<DragaliaResult> RecordMulti(DungeonRecordRecordMultiRequest request)
+    public DragaliaResult RecordMulti(DungeonRecordRecordMultiRequest request)
     {
-        return RedirectToAction("Record", request);
-
-        DungeonSession session = await this.dungeonService.FinishDungeon(request.dungeon_key);
-
-        await this.userDataRepository.AddTutorialFlag(this.DeviceAccountId, 1022);
-        await this.questRepository.CompleteQuest(this.DeviceAccountId, session.DungeonId);
-
-        DbPlayerUserData userData = await this.userDataRepository
-            .GetUserData(this.DeviceAccountId)
-            .SingleAsync();
-
-        userData.Exp += 1;
-        userData.ManaPoint += 1000;
-        userData.Coin += 1000;
-
-        UpdateDataList updateDataList = this.updateDataService.GetUpdateDataList(
-            this.DeviceAccountId
-        );
-
-        await this.questRepository.SaveChangesAsync();
-
-        return this.Ok(
-            new DungeonRecordRecordMultiData()
-            {
-                ingame_result_data = new()
-                {
-                    dungeon_key = request.dungeon_key,
-                    play_type = 1,
-                    quest_id = session.DungeonId,
-                    reward_record = new()
-                    {
-                        drop_all = new List<AtgenDropAll>()
-                        {
-                            new()
-                            {
-                                type = EntityTypes.Material,
-                                id = 201014003, // Squishum
-                                quantity = 1,
-                                place = 0,
-                                factor = 0
-                            }
-                        },
-                        first_clear_set = new List<AtgenFirstClearSet>()
-                        {
-                            new()
-                            {
-                                type = (int)EntityTypes.Wyrmite,
-                                id = 0,
-                                quantity = 5
-                            }
-                        },
-                        take_coin = 1000,
-                        take_astral_item_quantity = 300,
-                        missions_clear_set = Enumerable
-                            .Range(1, 3)
-                            .Select(
-                                x =>
-                                    new AtgenMissionsClearSet()
-                                    {
-                                        type = 23,
-                                        id = 0,
-                                        quantity = 5,
-                                        mission_no = x
-                                    }
-                            ),
-                        mission_complete = new List<AtgenFirstClearSet>()
-                        {
-                            new()
-                            {
-                                type = (int)EntityTypes.Wyrmite,
-                                id = 0,
-                                quantity = 1234
-                            }
-                        },
-                        enemy_piece = new List<AtgenEnemyPiece>(),
-                        reborn_bonus = new List<AtgenFirstClearSet>(),
-                        quest_bonus_list = new List<AtgenFirstClearSet>(),
-                        carry_bonus = new List<AtgenFirstClearSet>(),
-                        challenge_quest_bonus_list = new List<AtgenFirstClearSet>(),
-                        campaign_extra_reward_list = new List<AtgenFirstClearSet>(),
-                        weekly_limit_reward_list = new List<AtgenFirstClearSet>(),
-                    },
-                    grow_record = new()
-                    {
-                        take_player_exp = 1,
-                        take_chara_exp = 4000,
-                        take_mana = 1000,
-                        bonus_factor = 1,
-                        mana_bonus_factor = 1,
-                        chara_grow_record = session.Party.Select(
-                            x =>
-                                new AtgenCharaGrowRecord()
-                                {
-                                    chara_id = (int)x.chara_id,
-                                    take_exp = 240
-                                }
-                        ),
-                        chara_friendship_list = new List<CharaFriendshipList>()
-                    },
-                    start_time = DateTimeOffset.UtcNow,
-                    end_time = DateTimeOffset.FromUnixTimeSeconds(0),
-                    current_play_count = 1,
-                    is_clear = false,
-                    state = 1,
-                    is_host = true,
-                    reborn_count = 0,
-                    helper_list = new List<UserSupportList>(),
-                    helper_detail_list = new List<AtgenHelperDetailList>(),
-                    quest_party_setting_list = session.Party,
-                    bonus_factor_list = new List<AtgenBonusFactorList>(),
-                    scoring_enemy_point_list = new List<AtgenScoringEnemyPointList>(),
-                    score_mission_success_list = new List<AtgenScoreMissionSuccessList>(),
-                    event_passive_up_list = new List<AtgenEventPassiveUpList>(),
-                    clear_time = 70,
-                    is_best_clear_time = true,
-                    converted_entity_list = new List<ConvertedEntityList>(),
-                    dungeon_skip_type = 0,
-                    total_play_damage = 0,
-                },
-                update_data_list = updateDataList,
-                entity_result = new(),
-            }
-        );
+        return RedirectToActionPreserveMethod("Record", routeValues: new { request });
     }
 
     private static class DefaultDrops
@@ -378,6 +255,10 @@ public class DungeonRecordController : DragaliaControllerBase
 
         public static readonly IReadOnlyList<Materials> MiscUpgrade = new List<Materials>()
         {
+            // === Crystals ===
+            Materials.GoldCrystal,
+            Materials.SilverCrystal,
+            Materials.BronzeCrystal,
             // === Testaments ===
             Materials.ChampionsTestament,
             Materials.KnightsTestament,

--- a/DragaliaAPI/Controllers/Dragalia/ItemController.cs
+++ b/DragaliaAPI/Controllers/Dragalia/ItemController.cs
@@ -1,0 +1,30 @@
+﻿using AutoMapper;
+using DragaliaAPI.Database.Repositories;
+using DragaliaAPI.Models.Generated;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DragaliaAPI.Controllers.Dragalia;
+
+[Route("item")]
+public class ItemController : DragaliaControllerBase
+{
+    private readonly IInventoryRepository inventoryRepository;
+    private readonly IMapper mapper;
+
+    public ItemController(IInventoryRepository inventoryRepository, IMapper mapper)
+    {
+        this.inventoryRepository = inventoryRepository;
+        this.mapper = mapper;
+    }
+
+    [HttpPost("get_list")]
+    public async Task<DragaliaResult> GetList()
+    {
+        IEnumerable<ItemList> itemList = this.inventoryRepository
+            .GetMaterials(this.DeviceAccountId)
+            .Select(mapper.Map<ItemList>);
+
+        return this.Ok(new ItemGetListData() { item_list = itemList });
+    }
+}

--- a/DragaliaAPI/Models/AutoMapper/InventoryMapProfile.cs
+++ b/DragaliaAPI/Models/AutoMapper/InventoryMapProfile.cs
@@ -9,6 +9,7 @@ public class InventoryMapProfile : Profile
     public InventoryMapProfile()
     {
         this.CreateMap<DbPlayerMaterial, MaterialList>();
+        this.CreateMap<DbPlayerMaterial, ItemList>();
 
         this.SourceMemberNamingConvention = DatabaseNamingConvention.Instance;
         this.DestinationMemberNamingConvention = LowerUnderscoreNamingConvention.Instance;

--- a/DragaliaAPI/Models/AutoMapper/InventoryMapProfile.cs
+++ b/DragaliaAPI/Models/AutoMapper/InventoryMapProfile.cs
@@ -9,7 +9,8 @@ public class InventoryMapProfile : Profile
     public InventoryMapProfile()
     {
         this.CreateMap<DbPlayerMaterial, MaterialList>();
-        this.CreateMap<DbPlayerMaterial, ItemList>();
+        this.CreateMap<DbPlayerMaterial, ItemList>()
+            .ForMember(x => x.item_id, opts => opts.MapFrom(src => src.MaterialId));
 
         this.SourceMemberNamingConvention = DatabaseNamingConvention.Instance;
         this.DestinationMemberNamingConvention = LowerUnderscoreNamingConvention.Instance;

--- a/DragaliaAPI/Models/Generated/Components.cs
+++ b/DragaliaAPI/Models/Generated/Components.cs
@@ -1854,12 +1854,12 @@ public class AtgenDrawDetails
 public class AtgenDropAll
 {
     public int id { get; set; }
-    public int type { get; set; }
+    public EntityTypes type { get; set; }
     public int quantity { get; set; }
     public int place { get; set; }
     public float factor { get; set; }
 
-    public AtgenDropAll(int id, int type, int quantity, int place, float factor)
+    public AtgenDropAll(int id, EntityTypes type, int quantity, int place, float factor)
     {
         this.id = id;
         this.type = type;


### PR DESCRIPTION
- Gives players a selection of maxed out wyrmprints, dragons, and weapons upon creating a savefile 
- Drops a random selection of upgrade materials from all quests
- Adds ItemController and `item/get_list` to view material info
- Misc. tidying up and fixes in:
    - SummonController
    - DungeonRecordController
    - DeveloperAuthorization


The hope is that with these default items, it won't be necessary to import a savefile to test most functionality of the server -- though many players will probably still want to do so.