### PR TITLE
Fix resource version string when attempting to connect on iOS

### DIFF
--- a/DragaliaAPI.Test/Integration/Dragalia/VersionTest.cs
+++ b/DragaliaAPI.Test/Integration/Dragalia/VersionTest.cs
@@ -3,15 +3,15 @@
 namespace DragaliaAPI.Test.Integration.Dragalia;
 
 /// <summary>
-/// Tests <see cref="Controllers.Dragalia.GetResourceVersionController"/>
+/// Tests <see cref="Controllers.Dragalia.VersionController"/>
 /// </summary>
 [Collection("DragaliaIntegration")]
-public class GetResourceVersionTest : IClassFixture<IntegrationTestFixture>
+public class VersionTest : IClassFixture<IntegrationTestFixture>
 {
     private readonly HttpClient client;
     private readonly IntegrationTestFixture fixture;
 
-    public GetResourceVersionTest(IntegrationTestFixture fixture)
+    public VersionTest(IntegrationTestFixture fixture)
     {
         this.fixture = fixture;
         client = fixture.CreateClient(
@@ -19,16 +19,21 @@ public class GetResourceVersionTest : IClassFixture<IntegrationTestFixture>
         );
     }
 
-    [Fact]
-    public async Task GetResourceVersion_ReturnsCorrectResponse()
+    [Theory]
+    [InlineData(1, "b1HyoeTFegeTexC0")]
+    [InlineData(2, "y2XM6giU6zz56wCm")]
+    public async Task GetResourceVersion_ReturnsCorrectResponse(
+        int platform,
+        string expectedVersion
+    )
     {
         VersionGetResourceVersionData response = (
             await client.PostMsgpack<VersionGetResourceVersionData>(
                 "version/get_resource_version",
-                new VersionGetResourceVersionRequest(0, "whatever")
+                new VersionGetResourceVersionRequest(platform, "whatever")
             )
         ).data;
 
-        response.resource_version.Should().Be("y2XM6giU6zz56wCm");
+        response.resource_version.Should().Be(expectedVersion);
     }
 }

--- a/DragaliaAPI/Controllers/Dragalia/VersionController.cs
+++ b/DragaliaAPI/Controllers/Dragalia/VersionController.cs
@@ -7,14 +7,22 @@ namespace DragaliaAPI.Controllers.Dragalia;
 [Consumes("application/octet-stream")]
 [Produces("application/octet-stream")]
 [ApiController]
-public class GetResourceVersionController : DragaliaControllerBase
+public class VersionController : DragaliaControllerBase
 {
-    private const string ResourceVersion = "y2XM6giU6zz56wCm";
+    private const string AndroidResourceVersion = "y2XM6giU6zz56wCm";
+    private const string IosResourceVersion = "b1HyoeTFegeTexC0";
 
     [HttpPost]
     [Route("get_resource_version")]
-    public DragaliaResult GetVersionList()
+    public DragaliaResult GetResourceVersion(VersionGetResourceVersionRequest request)
     {
-        return this.Ok(new VersionGetResourceVersionData(ResourceVersion));
+        string resourceVersion = request.platform switch
+        {
+            1 => IosResourceVersion,
+            2 => AndroidResourceVersion,
+            _ => throw new BadHttpRequestException("Invalid platform identifier")
+        };
+
+        return this.Ok(new VersionGetResourceVersionData(resourceVersion));
     }
 }

--- a/DragaliaAPI/Controllers/Dragalia/VersionController.cs
+++ b/DragaliaAPI/Controllers/Dragalia/VersionController.cs
@@ -4,9 +4,6 @@ using Microsoft.AspNetCore.Mvc;
 namespace DragaliaAPI.Controllers.Dragalia;
 
 [Route("version")]
-[Consumes("application/octet-stream")]
-[Produces("application/octet-stream")]
-[ApiController]
 public class VersionController : DragaliaControllerBase
 {
     private const string AndroidResourceVersion = "y2XM6giU6zz56wCm";


### PR DESCRIPTION
iOS users previous would 404 as the game attempts to download an iOS manifest that doesn't exist. Correctly switch the resource version string that is sent by /version/get_resource_version based on platform ID to fix this.