### PR TITLE
Bug fixes

### DIFF
--- a/DragaliaAPI.Database.Test/Repositories/UserDataRepositoryTest.cs
+++ b/DragaliaAPI.Database.Test/Repositories/UserDataRepositoryTest.cs
@@ -31,13 +31,29 @@ public class UserDataRepositoryTest : IClassFixture<DbTestFixture>
     [Fact]
     public async Task UpdateTutorialStatus_UpdatesTutorialStatus()
     {
-        await this.userDataRepository.UpdateTutorialStatus("id", 200);
+        await this.userDataRepository.UpdateTutorialStatus("id", 80000);
         await this.userDataRepository.SaveChangesAsync();
 
         this.fixture.ApiContext.PlayerUserData
             .Single(x => x.DeviceAccountId == "id")
             .TutorialStatus.Should()
-            .Be(200);
+            .Be(80000);
+    }
+
+    [Fact]
+    public async Task UpdateTutorialStatus_LowerStatus_DoesNotUpdateTutorialStatus()
+    {
+        int existingStatus = this.fixture.ApiContext.PlayerUserData
+            .Single(x => x.DeviceAccountId == "id")
+            .TutorialStatus;
+
+        await this.userDataRepository.UpdateTutorialStatus("id", 0);
+        await this.userDataRepository.SaveChangesAsync();
+
+        this.fixture.ApiContext.PlayerUserData
+            .Single(x => x.DeviceAccountId == "id")
+            .TutorialStatus.Should()
+            .Be(existingStatus);
     }
 
     [Fact]

--- a/DragaliaAPI.Database/Entities/DbPlayerUserData.cs
+++ b/DragaliaAPI.Database/Entities/DbPlayerUserData.cs
@@ -35,7 +35,7 @@ public class DbPlayerUserData : IDbHasAccountId
     /// <summary>
     /// The player's rupie balance.
     /// </summary>
-    public int Coin { get; set; }
+    public long Coin { get; set; }
 
     public int MaxDragonQuantity { get; set; }
 

--- a/DragaliaAPI.Database/Migrations/20221227191147_develop_1.Designer.cs
+++ b/DragaliaAPI.Database/Migrations/20221227191147_develop_1.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DragaliaAPI.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DragaliaAPI.Database.Migrations
 {
     [DbContext(typeof(ApiContext))]
-    partial class ApiContextModelSnapshot : ModelSnapshot
+    [Migration("20221227191147_develop_1")]
+    partial class develop1
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DragaliaAPI.Database/Migrations/20221227191147_develop_1.cs
+++ b/DragaliaAPI.Database/Migrations/20221227191147_develop_1.cs
@@ -1,0 +1,34 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DragaliaAPI.Database.Migrations
+{
+    /// <inheritdoc />
+    public partial class develop1 : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<long>(
+                name: "Coin",
+                table: "PlayerUserData",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "integer");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<int>(
+                name: "Coin",
+                table: "PlayerUserData",
+                type: "integer",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+        }
+    }
+}

--- a/DragaliaAPI.Database/Repositories/DeviceAccountRepository.cs
+++ b/DragaliaAPI.Database/Repositories/DeviceAccountRepository.cs
@@ -87,6 +87,14 @@ public class DeviceAccountRepository : BaseRepository, IDeviceAccountRepository
 
     private async Task AddDefaultWyrmprints(string deviceAccountId)
     {
+        await this.apiContext.PlayerAbilityCrests.AddAsync(
+            new DbAbilityCrest()
+            {
+                DeviceAccountId = deviceAccountId,
+                AbilityCrestId = AbilityCrests.ManaFount
+            }
+        );
+
         await this.apiContext.PlayerAbilityCrests.AddRangeAsync(
             DefaultSavefileData.FiveStarCrests
                 .Select(

--- a/DragaliaAPI.Database/Repositories/IUserDataRepository.cs
+++ b/DragaliaAPI.Database/Repositories/IUserDataRepository.cs
@@ -11,5 +11,5 @@ public interface IUserDataRepository : IBaseRepository
     Task SetTutorialFlags(string deviceAccountId, ISet<int> tutorialFlags);
     Task SkipTutorial(string deviceAccountId);
     Task UpdateName(string deviceAccountId, string newName);
-    Task<DbPlayerUserData> UpdateTutorialStatus(string deviceAccountId, int newStatus);
+    Task UpdateTutorialStatus(string deviceAccountId, int newStatus);
 }

--- a/DragaliaAPI.Database/Repositories/UserDataRepository.cs
+++ b/DragaliaAPI.Database/Repositories/UserDataRepository.cs
@@ -24,12 +24,12 @@ public class UserDataRepository : BaseRepository, IUserDataRepository
         return infoQuery;
     }
 
-    public async Task<DbPlayerUserData> UpdateTutorialStatus(string deviceAccountId, int newStatus)
+    public async Task UpdateTutorialStatus(string deviceAccountId, int newStatus)
     {
         DbPlayerUserData userData = await this.LookupUserData(deviceAccountId);
 
-        userData.TutorialStatus = newStatus;
-        return userData;
+        if (newStatus > userData.TutorialStatus)
+            userData.TutorialStatus = newStatus;
     }
 
     public async Task<ISet<int>> GetTutorialFlags(string deviceAccountId)

--- a/DragaliaAPI.Test/Integration/Dragalia/CharaTest.cs
+++ b/DragaliaAPI.Test/Integration/Dragalia/CharaTest.cs
@@ -207,11 +207,16 @@ public class CharaTest : IClassFixture<IntegrationTestFixture>
         ).data;
 
         CharaList responseCharaData = response.update_data_list.chara_list
-            .Where(x => (Charas)x.chara_id == Charas.SummerCelliera)
+            .Where(x => x.chara_id == Charas.SummerCelliera)
             .First();
 
         responseCharaData.level.Should().Be(100);
         responseCharaData.exp.Should().Be(CharaConstants.XpLimits[99]);
+
+        // Values from wiki
+        responseCharaData.hp.Should().Be(956);
+        responseCharaData.attack.Should().Be(574);
+
         responseCharaData.limit_break_count.Should().Be(5);
         responseCharaData.mana_circle_piece_id_list
             .Should()

--- a/DragaliaAPI.Test/Integration/Dragalia/TutorialTest.cs
+++ b/DragaliaAPI.Test/Integration/Dragalia/TutorialTest.cs
@@ -31,7 +31,7 @@ public class TutorialTest : IClassFixture<IntegrationTestFixture>
     [Fact]
     public async Task TutorialUpdateStep_UpdatesDB()
     {
-        int step = 2;
+        int step = 20000;
 
         TutorialUpdateStepData response = (
             await client.PostMsgpack<TutorialUpdateStepData>(
@@ -51,7 +51,7 @@ public class TutorialTest : IClassFixture<IntegrationTestFixture>
     [Fact]
     public async Task TutorialUpdateStep_ReturnsCorrectResponse()
     {
-        int step = 2;
+        int step = 20000;
 
         using IServiceScope scope = fixture.Services.CreateScope();
         IUserDataRepository userDataRepository =

--- a/DragaliaAPI/Controllers/Dragalia/CharaController.cs
+++ b/DragaliaAPI/Controllers/Dragalia/CharaController.cs
@@ -45,7 +45,6 @@ public class CharaController : DragaliaControllerBase
         this.updateDataService = updateDataService;
         this.mapper = mapper;
         _charaDataService = charaDataService;
-        _sessionService = sessionService;
     }
 
     [Route("awake")]

--- a/DragaliaAPI/Controllers/Dragalia/CharaController.cs
+++ b/DragaliaAPI/Controllers/Dragalia/CharaController.cs
@@ -9,6 +9,7 @@ using DragaliaAPI.Models;
 using DragaliaAPI.Models.Generated;
 using DragaliaAPI.Models.Nintendo;
 using DragaliaAPI.Services;
+using DragaliaAPI.Services.Exceptions;
 using DragaliaAPI.Shared.Definitions;
 using DragaliaAPI.Shared.Definitions.Enums;
 using DragaliaAPI.Shared.Services;
@@ -20,13 +21,9 @@ using static DragaliaAPI.Shared.Definitions.Enums.ManaNodesUtil;
 namespace DragaliaAPI.Controllers.Dragalia;
 
 [Route("chara")]
-[Consumes("application/octet-stream")]
-[Produces("application/octet-stream")]
-[ApiController]
 public class CharaController : DragaliaControllerBase
 {
     private readonly ICharaDataService _charaDataService;
-    private readonly ISessionService _sessionService;
     private readonly IUserDataRepository userDataRepository;
     private readonly IUnitRepository unitRepository;
     private readonly IInventoryRepository inventoryRepository;
@@ -39,8 +36,7 @@ public class CharaController : DragaliaControllerBase
         IInventoryRepository inventoryRepository,
         IUpdateDataService updateDataService,
         IMapper mapper,
-        ICharaDataService charaDataService,
-        ISessionService sessionService
+        ICharaDataService charaDataService
     )
     {
         this.userDataRepository = userDataRepository;
@@ -54,121 +50,102 @@ public class CharaController : DragaliaControllerBase
 
     [Route("awake")]
     [HttpPost]
-    public async Task<DragaliaResult> Awake(
-        [FromHeader(Name = "SID")] string sessionId,
-        [FromBody] CharaAwakeRequest request
-    )
+    public async Task<DragaliaResult> Awake([FromBody] CharaAwakeRequest request)
     {
-        try
+        if (request.next_rarity > 5)
         {
-            if (request.next_rarity > 5)
-            {
-                throw new ArgumentException("Cannot enhance beyond rarity 5");
-            }
-
-            DbPlayerUserData userData = await this.userDataRepository
-                .GetUserData(this.DeviceAccountId)
-                .FirstAsync();
-            DbPlayerCharaData playerCharData = await unitRepository
-                .GetAllCharaData(this.DeviceAccountId)
-                .FirstAsync(chara => chara.CharaId == (Charas)request.chara_id);
-            DataAdventurer charData = _charaDataService.GetData((int)request.chara_id);
-            playerCharData.HpBase += (ushort)(
-                request.next_rarity == 4
-                    ? charData.MinHp4 - charData.MinHp3
-                    : charData.MinHp5 - charData.MinHp4
+            throw new DragaliaException(
+                ResultCode.CHARA_GROW_AWAKE_RARITY_INVALID,
+                "Invalid requested rarity"
             );
-            playerCharData.AttackBase += (ushort)(
-                request.next_rarity == 4
-                    ? charData.MinAtk4 - charData.MinAtk3
-                    : charData.MinAtk5 - charData.MinAtk4
-            );
-            playerCharData.Rarity = (byte)request.next_rarity;
-            //TODO Get and update missions relating to promoting characters
-            //MissionNoticeData missionNoticeData = null;
-
-            UpdateDataList updateDataList = this.updateDataService.GetUpdateDataList(
-                this.DeviceAccountId
-            );
-
-            await unitRepository.SaveChangesAsync();
-
-            return Ok(new CharaBuildupData(updateDataList, new()));
         }
-        catch (Exception)
-        {
-            return BadRequest();
-        }
+
+        DbPlayerUserData userData = await this.userDataRepository
+            .GetUserData(this.DeviceAccountId)
+            .FirstAsync();
+        DbPlayerCharaData playerCharData = await unitRepository
+            .GetAllCharaData(this.DeviceAccountId)
+            .FirstAsync(chara => chara.CharaId == (Charas)request.chara_id);
+        DataAdventurer charData = _charaDataService.GetData((int)request.chara_id);
+        playerCharData.HpBase += (ushort)(
+            request.next_rarity == 4
+                ? charData.MinHp4 - charData.MinHp3
+                : charData.MinHp5 - charData.MinHp4
+        );
+        playerCharData.AttackBase += (ushort)(
+            request.next_rarity == 4
+                ? charData.MinAtk4 - charData.MinAtk3
+                : charData.MinAtk5 - charData.MinAtk4
+        );
+        playerCharData.Rarity = (byte)request.next_rarity;
+        //TODO Get and update missions relating to promoting characters
+        //MissionNoticeData missionNoticeData = null;
+
+        UpdateDataList updateDataList = this.updateDataService.GetUpdateDataList(
+            this.DeviceAccountId
+        );
+
+        await unitRepository.SaveChangesAsync();
+
+        return Ok(new CharaBuildupData(updateDataList, new()));
     }
 
     [Route("buildup")]
     [HttpPost]
-    public async Task<DragaliaResult> Buildup(
-        [FromHeader(Name = "SID")] string sessionId,
-        [FromBody] CharaBuildupRequest request
-    )
+    public async Task<DragaliaResult> Buildup([FromBody] CharaBuildupRequest request)
     {
-        try
+        IEnumerable<Materials> matIds = request.material_list.Select(x => x.id).Cast<Materials>();
+
+        Dictionary<Materials, DbPlayerMaterial> dbMats = await this.inventoryRepository
+            .GetMaterials(this.DeviceAccountId)
+            .Where(dbMat => matIds.Contains(dbMat.MaterialId))
+            .ToDictionaryAsync(dbMat => dbMat.MaterialId);
+        foreach (AtgenEnemyPiece mat in request.material_list)
         {
-            IEnumerable<Materials> matIds = request.material_list
-                .Select(x => x.id)
-                .Cast<Materials>();
-
-            Dictionary<Materials, DbPlayerMaterial> dbMats = await this.inventoryRepository
-                .GetMaterials(this.DeviceAccountId)
-                .Where(dbMat => matIds.Contains(dbMat.MaterialId))
-                .ToDictionaryAsync(dbMat => dbMat.MaterialId);
-            foreach (AtgenEnemyPiece mat in request.material_list)
+            if (mat.quantity < 0)
             {
-                if (mat.quantity < 0)
-                {
-                    throw new ArgumentException("Invalid quantity for MaterialList");
-                }
-                if (
-                    mat.id != Materials.BronzeCrystal
-                    && mat.id != Materials.SilverCrystal
-                    && mat.id != Materials.GoldCrystal
-                    && mat.id != Materials.AmplifyingCrystal
-                    && mat.id != Materials.FortifyingCrystal
-                )
-                {
-                    throw new ArgumentException("Invalid MaterialList in request");
-                }
-                if (!dbMats.ContainsKey(mat.id) || dbMats[mat.id].Quantity < mat.quantity)
-                {
-                    throw new ArgumentException("Insufficient materials for buildup");
-                }
+                throw new ArgumentException("Invalid quantity for MaterialList");
             }
-            DbPlayerUserData userData = await this.userDataRepository
-                .GetUserData(this.DeviceAccountId)
-                .FirstAsync();
-            DbPlayerCharaData playerCharData = await this.unitRepository
-                .GetAllCharaData(this.DeviceAccountId)
-                .FirstAsync(chara => chara.CharaId == (Charas)request.chara_id);
-
-            Dictionary<int, int> usedMaterials = new();
-            CharaLevelUp(request.material_list, ref playerCharData, ref usedMaterials);
-            List<MaterialList> remainingMaterials = new();
-            foreach (KeyValuePair<int, int> mat in usedMaterials)
+            if (
+                mat.id != Materials.BronzeCrystal
+                && mat.id != Materials.SilverCrystal
+                && mat.id != Materials.GoldCrystal
+                && mat.id != Materials.AmplifyingCrystal
+                && mat.id != Materials.FortifyingCrystal
+            )
             {
-                dbMats[(Materials)mat.Key].Quantity -= mat.Value;
-                remainingMaterials.Add(this.mapper.Map<MaterialList>(dbMats[(Materials)mat.Key]));
+                throw new ArgumentException("Invalid MaterialList in request");
             }
-
-            //TODO Add element/weapontype bonus if applicable
-
-            UpdateDataList updateDataList = this.updateDataService.GetUpdateDataList(
-                this.DeviceAccountId
-            );
-
-            await unitRepository.SaveChangesAsync();
-
-            return Ok(new CharaBuildupData(updateDataList, new()));
+            if (!dbMats.ContainsKey(mat.id) || dbMats[mat.id].Quantity < mat.quantity)
+            {
+                throw new ArgumentException("Insufficient materials for buildup");
+            }
         }
-        catch (Exception)
+        DbPlayerUserData userData = await this.userDataRepository
+            .GetUserData(this.DeviceAccountId)
+            .FirstAsync();
+        DbPlayerCharaData playerCharData = await this.unitRepository
+            .GetAllCharaData(this.DeviceAccountId)
+            .FirstAsync(chara => chara.CharaId == (Charas)request.chara_id);
+
+        Dictionary<int, int> usedMaterials = new();
+        CharaLevelUp(request.material_list, ref playerCharData, ref usedMaterials);
+        List<MaterialList> remainingMaterials = new();
+        foreach (KeyValuePair<int, int> mat in usedMaterials)
         {
-            return BadRequest();
+            dbMats[(Materials)mat.Key].Quantity -= mat.Value;
+            remainingMaterials.Add(this.mapper.Map<MaterialList>(dbMats[(Materials)mat.Key]));
         }
+
+        //TODO Add element/weapontype bonus if applicable
+
+        UpdateDataList updateDataList = this.updateDataService.GetUpdateDataList(
+            this.DeviceAccountId
+        );
+
+        await unitRepository.SaveChangesAsync();
+
+        return Ok(new CharaBuildupData(updateDataList, new()));
     }
 
     private void CharaLevelUp(
@@ -336,22 +313,84 @@ public class CharaController : DragaliaControllerBase
     [HttpPost]
     public async Task<DragaliaResult> CharaBuildupMana([FromBody] CharaBuildupManaRequest request)
     {
-        if (request.mana_circle_piece_id_list == null)
+        DbPlayerUserData userData = await this.userDataRepository
+            .GetUserData(this.DeviceAccountId)
+            .FirstAsync();
+        DbPlayerCharaData playerCharData = await this.unitRepository
+            .GetAllCharaData(this.DeviceAccountId)
+            .FirstAsync(chara => chara.CharaId == (Charas)request.chara_id);
+        Dictionary<CurrencyTypes, int> usedCurrencies = new();
+        Dictionary<Materials, int> usedMaterials = new();
+        HashSet<int> unlockedStories = new();
+        await CharaManaNodeUnlock(
+            request.mana_circle_piece_id_list,
+            playerCharData,
+            usedCurrencies,
+            usedMaterials,
+            unlockedStories,
+            request.is_use_grow_material == 1
+                ? CharaUpgradeMaterialTypes.GrowthMaterial
+                : CharaUpgradeMaterialTypes.Standard
+        );
+        //TODO: Party power calculation call
+
+        UpdateDataList updateDataList = this.updateDataService.GetUpdateDataList(
+            this.DeviceAccountId
+        );
+
+        await userDataRepository.SaveChangesAsync();
+
+        return this.Ok(new CharaBuildupData(updateDataList, new()));
+    }
+
+    [Route("limit_break")]
+    [HttpPost]
+    public async Task<DragaliaResult> CharaLimitBreak([FromBody] CharaLimitBreakRequest request)
+    {
+        DbPlayerUserData userData = await this.userDataRepository
+            .GetUserData(this.DeviceAccountId)
+            .FirstAsync();
+        DbPlayerCharaData playerCharData = await this.unitRepository
+            .GetAllCharaData(this.DeviceAccountId)
+            .FirstAsync(chara => chara.CharaId == (Charas)request.chara_id);
+        Dictionary<CurrencyTypes, int> usedCurrencies = new();
+        Dictionary<Materials, int> usedMaterials = new();
+        playerCharData.LimitBreakCount = (byte)request.next_limit_break_count;
+        if (request.next_limit_break_count == 6)
         {
-            return BadRequest();
+            playerCharData.AdditionalMaxLevel += 5;
         }
-        try
+
+        UpdateDataList updateDataList = this.updateDataService.GetUpdateDataList(
+            this.DeviceAccountId
+        );
+
+        await unitRepository.SaveChangesAsync();
+
+        return Ok(new CharaBuildupData(updateDataList, new()));
+    }
+
+    [Route("limit_break_and_buildup_mana")]
+    [HttpPost]
+    public async Task<DragaliaResult> CharaLimitBreakAndMana(
+        [FromBody] CharaLimitBreakAndBuildupManaRequest request
+    )
+    {
+        DbPlayerUserData userData = await this.userDataRepository
+            .GetUserData(this.DeviceAccountId)
+            .FirstAsync();
+        DbPlayerCharaData playerCharData = await this.unitRepository
+            .GetAllCharaData(this.DeviceAccountId)
+            .FirstAsync(chara => chara.CharaId == request.chara_id);
+        Dictionary<CurrencyTypes, int> usedCurrencies = new();
+        Dictionary<Materials, int> usedMaterials = new();
+        HashSet<int> unlockedStories = new();
+
+        playerCharData.LimitBreakCount = (byte)request.next_limit_break_count;
+
+        if (request.mana_circle_piece_id_list.Any())
         {
-            DbPlayerUserData userData = await this.userDataRepository
-                .GetUserData(this.DeviceAccountId)
-                .FirstAsync();
-            DbPlayerCharaData playerCharData = await this.unitRepository
-                .GetAllCharaData(this.DeviceAccountId)
-                .FirstAsync(chara => chara.CharaId == (Charas)request.chara_id);
-            Dictionary<CurrencyTypes, int> usedCurrencies = new();
-            Dictionary<Materials, int> usedMaterials = new();
-            HashSet<int> unlockedStories = new();
-            CharaManaNodeUnlock(
+            await CharaManaNodeUnlock(
                 request.mana_circle_piece_id_list,
                 playerCharData,
                 usedCurrencies,
@@ -361,175 +400,65 @@ public class CharaController : DragaliaControllerBase
                     ? CharaUpgradeMaterialTypes.GrowthMaterial
                     : CharaUpgradeMaterialTypes.Standard
             );
-            //TODO: Party power calculation call
-
-            UpdateDataList updateDataList = this.updateDataService.GetUpdateDataList(
-                this.DeviceAccountId
-            );
-
-            await userDataRepository.SaveChangesAsync();
-
-            return this.Ok(new CharaBuildupData(updateDataList, new()));
         }
-        catch (Exception)
-        {
-            return BadRequest();
-        }
-    }
 
-    [Route("limit_break")]
-    [HttpPost]
-    public async Task<DragaliaResult> CharaLimitBreak([FromBody] CharaLimitBreakRequest request)
-    {
-        if (request.next_limit_break_count == null)
-        {
-            return BadRequest();
-        }
-        try
-        {
-            DbPlayerUserData userData = await this.userDataRepository
-                .GetUserData(this.DeviceAccountId)
-                .FirstAsync();
-            DbPlayerCharaData playerCharData = await this.unitRepository
-                .GetAllCharaData(this.DeviceAccountId)
-                .FirstAsync(chara => chara.CharaId == (Charas)request.chara_id);
-            Dictionary<CurrencyTypes, int> usedCurrencies = new();
-            Dictionary<Materials, int> usedMaterials = new();
-            playerCharData.LimitBreakCount = (byte)request.next_limit_break_count;
-            if (request.next_limit_break_count == 6)
-            {
-                playerCharData.AdditionalMaxLevel += 5;
-            }
+        UpdateDataList updateDataList = this.updateDataService.GetUpdateDataList(
+            this.DeviceAccountId
+        );
 
-            UpdateDataList updateDataList = this.updateDataService.GetUpdateDataList(
-                this.DeviceAccountId
-            );
+        await unitRepository.SaveChangesAsync();
 
-            await unitRepository.SaveChangesAsync();
-
-            return Ok(new CharaBuildupData(updateDataList, new()));
-        }
-        catch (Exception)
-        {
-            return BadRequest();
-        }
-    }
-
-    [Route("limit_break_and_buildup_mana")]
-    [HttpPost]
-    public async Task<DragaliaResult> CharaLimitBreakAndMana(
-        [FromHeader(Name = "SID")] string sessionId,
-        [FromBody] CharaLimitBreakAndBuildupManaRequest request
-    )
-    {
-        if (
-            request.next_limit_break_count == null
-            && (
-                request.mana_circle_piece_id_list == null
-                || !request.mana_circle_piece_id_list.Any()
-            )
-        )
-        {
-            return BadRequest();
-        }
-        try
-        {
-            DbPlayerUserData userData = await this.userDataRepository
-                .GetUserData(this.DeviceAccountId)
-                .FirstAsync();
-            DbPlayerCharaData playerCharData = await this.unitRepository
-                .GetAllCharaData(this.DeviceAccountId)
-                .FirstAsync(chara => chara.CharaId == request.chara_id);
-            Dictionary<CurrencyTypes, int> usedCurrencies = new();
-            Dictionary<Materials, int> usedMaterials = new();
-            HashSet<int> unlockedStories = new();
-            if (request.next_limit_break_count != null)
-            {
-                playerCharData.LimitBreakCount = (byte)request.next_limit_break_count;
-            }
-            if (
-                request.mana_circle_piece_id_list != null && request.mana_circle_piece_id_list.Any()
-            )
-            {
-                CharaManaNodeUnlock(
-                    request.mana_circle_piece_id_list,
-                    playerCharData,
-                    usedCurrencies,
-                    usedMaterials,
-                    unlockedStories,
-                    request.is_use_grow_material == 1
-                        ? CharaUpgradeMaterialTypes.GrowthMaterial
-                        : CharaUpgradeMaterialTypes.Standard
-                );
-            }
-
-            UpdateDataList updateDataList = this.updateDataService.GetUpdateDataList(
-                this.DeviceAccountId
-            );
-
-            await unitRepository.SaveChangesAsync();
-
-            return Ok(new CharaBuildupData(updateDataList, new()));
-        }
-        catch (Exception)
-        {
-            return BadRequest();
-        }
+        return Ok(new CharaBuildupData(updateDataList, new()));
     }
 
     [Route("buildup_platinum")]
     [HttpPost]
     public async Task<DragaliaResult> CharaBuildupPlatinum(
-        [FromHeader(Name = "SID")] string sessionId,
         [FromBody] CharaBuildupPlatinumRequest request
     )
     {
-        try
+        DbPlayerUserData userData = await this.userDataRepository
+            .GetUserData(this.DeviceAccountId)
+            .FirstAsync();
+        DbPlayerCharaData playerCharaData = await this.unitRepository
+            .GetAllCharaData(this.DeviceAccountId)
+            .FirstAsync(chara => chara.CharaId == (Charas)request.chara_id);
+        DataAdventurer charaData = _charaDataService.GetData(playerCharaData.CharaId);
+        playerCharaData.Rarity = 5;
+        bool hasSpiral = charaData.MaxLimitBreakCount > 4;
+        playerCharaData.Level = (byte)(
+            CharaConstants.MaxLevel + (hasSpiral ? CharaConstants.AddMaxLevel : 0)
+        );
+        playerCharaData.Exp = CharaConstants.XpLimits[playerCharaData.Level - 1];
+        playerCharaData.HpBase = hasSpiral ? (ushort)charaData.AddMaxHp1 : (ushort)charaData.MaxHp;
+        playerCharaData.AttackBase = hasSpiral
+            ? (ushort)charaData.AddMaxAtk1
+            : (ushort)charaData.MaxAtk;
+        if (playerCharaData.ManaNodeUnlockCount < 50)
         {
-            DbPlayerUserData userData = await this.userDataRepository
-                .GetUserData(this.DeviceAccountId)
-                .FirstAsync();
-            DbPlayerCharaData playerCharaData = await this.unitRepository
-                .GetAllCharaData(this.DeviceAccountId)
-                .FirstAsync(chara => chara.CharaId == (Charas)request.chara_id);
-            DataAdventurer charaData = _charaDataService.GetData(playerCharaData.CharaId);
-            playerCharaData.Rarity = 5;
-            bool hasSpiral = charaData.MaxLimitBreakCount > 4;
-            playerCharaData.Level = (byte)(
-                CharaConstants.MaxLevel + (hasSpiral ? CharaConstants.AddMaxLevel : 0)
-            );
-            playerCharaData.Exp = CharaConstants.XpLimits[playerCharaData.Level - 1];
-            playerCharaData.HpBase = hasSpiral
-                ? (ushort)charaData.AddMaxHp1
-                : (ushort)charaData.MaxHp;
-            playerCharaData.AttackBase = hasSpiral
-                ? (ushort)charaData.AddMaxAtk1
-                : (ushort)charaData.MaxAtk;
-            playerCharaData.LimitBreakCount = (byte)charaData.MaxLimitBreakCount;
-            ManaNodes maxManaNodes = hasSpiral ? ManaNodes.Circle7 : ManaNodesUtil.MaxManaNodes;
-            Dictionary<CurrencyTypes, int> usedCurrencies = new();
-            Dictionary<Materials, int> usedMaterials = new();
-            HashSet<int> unlockedStories = new();
-            CharaManaNodeUnlock(
-                ManaNodesUtil.GetSetFromManaNodes(maxManaNodes),
-                playerCharaData,
-                usedCurrencies,
-                usedMaterials,
-                unlockedStories,
-                CharaUpgradeMaterialTypes.Omnicite
-            );
-            UpdateDataList updateDataList = this.updateDataService.GetUpdateDataList(
-                this.DeviceAccountId
-            );
-
-            await unitRepository.SaveChangesAsync();
-
-            return Ok(new CharaBuildupData(updateDataList, new()));
+            playerCharaData.HpNode += (ushort)charaData.McFullBonusHp5;
+            playerCharaData.AttackNode += (ushort)charaData.McFullBonusAtk5;
         }
-        catch (Exception)
-        {
-            return BadRequest();
-        }
+        playerCharaData.LimitBreakCount = (byte)charaData.MaxLimitBreakCount;
+        ManaNodes maxManaNodes = hasSpiral ? ManaNodes.Circle7 : ManaNodesUtil.MaxManaNodes;
+        Dictionary<CurrencyTypes, int> usedCurrencies = new();
+        Dictionary<Materials, int> usedMaterials = new();
+        HashSet<int> unlockedStories = new();
+        await CharaManaNodeUnlock(
+            ManaNodesUtil.GetSetFromManaNodes(maxManaNodes),
+            playerCharaData,
+            usedCurrencies,
+            usedMaterials,
+            unlockedStories,
+            CharaUpgradeMaterialTypes.Omnicite
+        );
+        UpdateDataList updateDataList = this.updateDataService.GetUpdateDataList(
+            this.DeviceAccountId
+        );
+
+        await unitRepository.SaveChangesAsync();
+
+        return Ok(new CharaBuildupData(updateDataList, new()));
     }
 
     /// <summary>
@@ -541,7 +470,7 @@ public class CharaController : DragaliaControllerBase
     /// <param name="manaNodes">Mananodes to unlock</param>
     /// <param name="isUseSpecialMaterial"></param>
     /// <returns></returns>
-    private async void CharaManaNodeUnlock(
+    private async Task CharaManaNodeUnlock(
         IEnumerable<int> manaNodes,
         DbPlayerCharaData playerCharData,
         Dictionary<CurrencyTypes, int> usedCurrency,
@@ -729,11 +658,9 @@ public class CharaController : DragaliaControllerBase
         }
 
         SortedSet<int> nodes = playerCharData.ManaCirclePieceIdList;
-        bool isUnlockFullMCBonusOmnicite =
-            nodes.Count < 50 && isUseSpecialMaterial == CharaUpgradeMaterialTypes.Omnicite;
         nodes.AddRange(manaNodes);
 
-        if (nodes.Count == 50 || isUnlockFullMCBonusOmnicite)
+        if (nodes.Count == 50)
         {
             playerCharData.HpNode += (ushort)charaData.McFullBonusHp5;
             playerCharData.AttackNode += (ushort)charaData.McFullBonusAtk5;
@@ -745,64 +672,54 @@ public class CharaController : DragaliaControllerBase
     [Route("unlock_edit_skill")]
     [HttpPost]
     public async Task<DragaliaResult> CharaUnlockEditSkill(
-        [FromHeader(Name = "SID")] string sessionId,
         [FromBody] CharaUnlockEditSkillRequest request
     )
     {
-        try
+        DbPlayerUserData userData = await this.userDataRepository
+            .GetUserData(this.DeviceAccountId)
+            .FirstAsync();
+        DbPlayerCharaData playerCharData = await this.unitRepository
+            .GetAllCharaData(this.DeviceAccountId)
+            .FirstAsync(chara => chara.CharaId == request.chara_id);
+        DataAdventurer charData = _charaDataService.GetData(playerCharData.CharaId);
+        //TODO: For now trust the client won't send the id of a chara who isn't allowed to share
+        if (
+            playerCharData.Level < 80
+            || (ManaNodes)playerCharData.ManaNodeUnlockCount < (ManaNodes.Circle5 - 1)
+        )
         {
-            DbPlayerUserData userData = await this.userDataRepository
-                .GetUserData(this.DeviceAccountId)
-                .FirstAsync();
-            DbPlayerCharaData playerCharData = await this.unitRepository
-                .GetAllCharaData(this.DeviceAccountId)
-                .FirstAsync(chara => chara.CharaId == request.chara_id);
-            DataAdventurer charData = _charaDataService.GetData(playerCharData.CharaId);
-            //TODO: For now trust the client won't send the id of a chara who isn't allowed to share
-            if (
-                playerCharData.Level < 80
-                || (ManaNodes)playerCharData.ManaNodeUnlockCount < (ManaNodes.Circle5 - 1)
-            )
-            {
-                throw new ArgumentException("Adventurer not eligible to share skill");
-            }
-
-            Materials usedMat = UpgradeMaterials.tomes[charData.ElementalType];
-            int usedMatCount = charData.EditSkillCost;
-            DbPlayerMaterial? dbMat = await this.inventoryRepository.GetMaterial(
-                this.DeviceAccountId,
-                usedMat
-            );
-            if (dbMat == null || dbMat.Quantity < usedMatCount)
-            {
-                throw new ArgumentException("Insufficient materials in storage");
-            }
-            playerCharData.IsUnlockEditSkill = true;
-            dbMat.Quantity -= usedMatCount;
-            UpdateDataList updateDataList = this.updateDataService.GetUpdateDataList(
-                this.DeviceAccountId
-            );
-
-            await unitRepository.SaveChangesAsync();
-
-            return Ok(new CharaBuildupData(updateDataList, new()));
+            throw new ArgumentException("Adventurer not eligible to share skill");
         }
-        catch (Exception)
+
+        Materials usedMat = UpgradeMaterials.tomes[charData.ElementalType];
+        int usedMatCount = charData.EditSkillCost;
+        DbPlayerMaterial? dbMat = await this.inventoryRepository.GetMaterial(
+            this.DeviceAccountId,
+            usedMat
+        );
+        if (dbMat == null || dbMat.Quantity < usedMatCount)
         {
-            return BadRequest();
+            throw new ArgumentException("Insufficient materials in storage");
         }
+        playerCharData.IsUnlockEditSkill = true;
+        dbMat.Quantity -= usedMatCount;
+        UpdateDataList updateDataList = this.updateDataService.GetUpdateDataList(
+            this.DeviceAccountId
+        );
+
+        await unitRepository.SaveChangesAsync();
+
+        return Ok(new CharaBuildupData(updateDataList, new()));
     }
 
     [Route("get_chara_unit_set")]
     [HttpPost]
     public async Task<DragaliaResult> GetCharaUnitSet(
-        [FromHeader(Name = "SID")] string sessionId,
         [FromBody] CharaGetCharaUnitSetRequest request
     )
     {
-        string accountId = await _sessionService.GetDeviceAccountId_SessionId(sessionId);
         IDictionary<Charas, IEnumerable<DbSetUnit>> setUnitData = unitRepository.GetCharaSets(
-            accountId,
+            DeviceAccountId,
             request.chara_id_list.Select(x => (Charas)x)
         );
         return Ok(
@@ -847,14 +764,20 @@ public class CharaController : DragaliaControllerBase
     [Route("set_chara_unit_set")]
     [HttpPost]
     public async Task<DragaliaResult> SetCharaUnitSet(
-        [FromHeader(Name = "SID")] string sessionId,
         [FromBody] CharaSetCharaUnitSetRequest request
     )
     {
-        string accountId = await _sessionService.GetDeviceAccountId_SessionId(sessionId);
         DbSetUnit setUnitData =
-            await unitRepository.GetCharaSetData(accountId, request.chara_id, request.unit_set_no)
-            ?? unitRepository.AddCharaSetData(accountId, request.chara_id, request.unit_set_no);
+            await unitRepository.GetCharaSetData(
+                DeviceAccountId,
+                request.chara_id,
+                request.unit_set_no
+            )
+            ?? unitRepository.AddCharaSetData(
+                DeviceAccountId,
+                request.chara_id,
+                request.unit_set_no
+            );
         ;
 
         setUnitData.UnitSetName = request.unit_set_name;
@@ -888,7 +811,7 @@ public class CharaController : DragaliaControllerBase
         {
             chara_id = (int)request.chara_id,
             chara_unit_set_detail_list = unitRepository
-                .GetCharaSets(accountId, request.chara_id)
+                .GetCharaSets(DeviceAccountId, request.chara_id)
                 .Select(
                     x =>
                         new AtgenCharaUnitSetDetailList()
@@ -908,7 +831,7 @@ public class CharaController : DragaliaControllerBase
                         }
                 )
         };
-        UpdateDataList ul = updateDataService.GetUpdateDataList(accountId);
+        UpdateDataList ul = updateDataService.GetUpdateDataList(DeviceAccountId);
         ul.chara_unit_set_list = new List<CharaUnitSetList> { setList };
         return Ok(new CharaSetCharaUnitSetData() { update_data_list = ul, entity_result = null });
     }


### PR DESCRIPTION
- Fix tutorial steps being changed in an unexpected way after the tutorial skip override, by making it so a call to /tutorial/update_step will not update the tutorial step if the request value is lower than the db value. This was happening as the endpoint was called after the tutorial skip
    - This was also leading to the WP tutorial being triggered and causing a softlock before an upgrade was attempted because the print at index = 0 in new savefiles is maxed out. Adding a junk print (Mana Fount) before the other prints will fix this when we later enable this part of the tutorial.
- Adjust unawaited async void call in CharaController, hopefully closing #61 
- Fix MC50 bonus not being applied with omnicite, and add correct stat check to omnicite test, closing #60
- Change coins to be a long in the db (matching the generated type) so that over 2 billion coins can be owned. Migration also added for this.