### PR TITLE
Shared skill fix

### DIFF
--- a/DragaliaAPI.Database/Factories/DbPlayerCharaDataFactory.cs
+++ b/DragaliaAPI.Database/Factories/DbPlayerCharaDataFactory.cs
@@ -53,7 +53,7 @@ internal static class DbPlayerCharaDataFactory
             ExAbilityLevel = 1,
             ExAbility2Level = 1,
             IsTemporary = false,
-            IsUnlockEditSkill = false,
+            IsUnlockEditSkill = data.Availability == "Story",
             ManaCirclePieceIdList = new SortedSet<int>(),
             ListViewFlag = false,
             GetTime = DateTimeOffset.UtcNow

--- a/DragaliaAPI/Models/AutoMapper/UnitMapProfile.cs
+++ b/DragaliaAPI/Models/AutoMapper/UnitMapProfile.cs
@@ -40,17 +40,14 @@ public class UnitMapProfile : Profile
 
         this.CreateMap<DbWeaponBody, GameWeaponBody>()
             // TODO: actual mapping for this
-            .ForMember(x => x.skill_no, opts => opts.MapFrom(x => 0))
-            .ForMember(x => x.skill_level, opts => opts.MapFrom(x => 0))
-            .ForMember(x => x.ability_1_level, opts => opts.MapFrom(x => 0))
-            .ForMember(x => x.ability_2_level, opts => opts.MapFrom(x => 0));
+            .ForMember(x => x.skill_no, opts => opts.MapFrom(x => 1))
+            .ForMember(x => x.skill_level, opts => opts.MapFrom(x => 2))
+            .ForMember(x => x.ability_1_level, opts => opts.MapFrom(x => 2))
+            .ForMember(x => x.ability_2_level, opts => opts.MapFrom(x => 2));
 
         this.CreateMap<DbDetailedPartyUnit, PartyUnitList>()
             .ForMember(x => x.weapon_skin_data, opts => opts.Ignore())
-            .ForMember(x => x.edit_skill_1_chara_data, opts => opts.Ignore())
-            .ForMember(x => x.edit_skill_2_chara_data, opts => opts.Ignore())
-            .ForMember(x => x.game_weapon_passive_ability_list, opts => opts.Ignore())
-            .ForMember(x => x.talisman_data, opts => opts.Ignore());
+            .ForMember(x => x.game_weapon_passive_ability_list, opts => opts.Ignore());
 
         this.CreateMap<DbEditSkillData, EditSkillCharaData>();
 


### PR DESCRIPTION
Closes #64 

Story characters will have their shared skills unlocked by default when being added (not backwards compatible)

Weapon skills and abilities are always set to the max level but this will need to be revisited when weapon upgrading is implemented. These values are not tracked in the database because they are not sent by /load/index, so presumably they're calculated on the fly.  Additionally, skill_no is always set to 1 because I am unsure what this does, however it appears to work with Agito/PDT weapons just fine.