### PR TITLE
Increase party name length limit

### DIFF
--- a/DragaliaAPI.Database/Entities/DbAbilityCrest.cs
+++ b/DragaliaAPI.Database/Entities/DbAbilityCrest.cs
@@ -32,7 +32,6 @@ public class DbAbilityCrest : IDbHasAccountId
 
     /// <summary>
     /// Gets or sets a value indicating how many copies of the wyrmprint are owned.
-    /// <remarks>Misspelling of 'equippable' is intended for compatibility with the game.</remarks>
     /// </summary>
     public int EquipableCount { get; set; } = 1;
 

--- a/DragaliaAPI.Database/Entities/DbParty.cs
+++ b/DragaliaAPI.Database/Entities/DbParty.cs
@@ -13,7 +13,7 @@ public class DbParty : IDbHasAccountId
     [Required]
     public int PartyNo { get; set; }
 
-    [MaxLength(16)]
+    [MaxLength(64)]
     public string PartyName { get; set; } = string.Empty;
 
     public ICollection<DbPartyUnit> Units { get; set; } = null!;

--- a/DragaliaAPI.Database/Entities/DbWeaponBody.cs
+++ b/DragaliaAPI.Database/Entities/DbWeaponBody.cs
@@ -38,7 +38,6 @@ public class DbWeaponBody : IDbHasAccountId
 
     /// <summary>
     /// Gets or sets a value indicating how many copies of the weapon are owned.
-    /// <remarks>Misspelling of 'equippable' is intended for compatibility with the game.</remarks>
     /// </summary>
     public int EquipableCount { get; set; } = 1;
 

--- a/DragaliaAPI.Database/Migrations/20221229004711_develop_2.Designer.cs
+++ b/DragaliaAPI.Database/Migrations/20221229004711_develop_2.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DragaliaAPI.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DragaliaAPI.Database.Migrations
 {
     [DbContext(typeof(ApiContext))]
-    partial class ApiContextModelSnapshot : ModelSnapshot
+    [Migration("20221229004711_develop_2")]
+    partial class develop2
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DragaliaAPI.Database/Migrations/20221229004711_develop_2.cs
+++ b/DragaliaAPI.Database/Migrations/20221229004711_develop_2.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DragaliaAPI.Database.Migrations
+{
+    /// <inheritdoc />
+    public partial class develop2 : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "PartyName",
+                table: "PartyData",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(16)",
+                oldMaxLength: 16);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "PartyName",
+                table: "PartyData",
+                type: "character varying(16)",
+                maxLength: 16,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(64)",
+                oldMaxLength: 64);
+        }
+    }
+}


### PR DESCRIPTION
Valid savefiles were experiencing import failures. Turns out the game lets you have 20 characters, not 16. Boosted it to 64 just in case; it (probably) won't do any harm to store ones that may be longer. Example from fudging the db:

![image](https://user-images.githubusercontent.com/5047192/210014298-b441e67a-d6b6-43de-b60b-f4d6f0ad278c.png)

The client should never send a request containing a name over 20 characters anyway.