### PR TITLE
Add unit and castle stories

### DIFF
--- a/DragaliaAPI.Database/DatabaseConfiguration.cs
+++ b/DragaliaAPI.Database/DatabaseConfiguration.cs
@@ -36,7 +36,8 @@ public static class DatabaseConfiguration
             .AddScoped<IPartyRepository, PartyRepository>()
             .AddScoped<IQuestRepository, QuestRepository>()
             .AddScoped<IInventoryRepository, InventoryRepository>()
-            .AddScoped<IFortRepository, FortRepository>();
+            .AddScoped<IFortRepository, FortRepository>()
+            .AddScoped<IStoryRepository, StoryRepository>();
 
         return services;
     }

--- a/DragaliaAPI.Database/Entities/DbPlayerStoryState.cs
+++ b/DragaliaAPI.Database/Entities/DbPlayerStoryState.cs
@@ -9,7 +9,6 @@ public class DbPlayerStoryState : IDbHasAccountId
 {
     [Column("DeviceAccountId")]
     [Required]
-    [ForeignKey("DbDeviceAccount")]
     public string DeviceAccountId { get; set; } = null!;
 
     [Column("StoryType")]

--- a/DragaliaAPI.Database/Repositories/IInventoryRepository.cs
+++ b/DragaliaAPI.Database/Repositories/IInventoryRepository.cs
@@ -11,5 +11,6 @@ public interface IInventoryRepository : IBaseRepository
     DbPlayerMaterial AddMaterial(string deviceAccountId, Materials type);
     Task<DbPlayerMaterial?> GetMaterial(string deviceAccountId, Materials materialId);
     IQueryable<DbPlayerMaterial> GetMaterials(string deviceAccountId);
-    Task AddMaterials(string deviceAccountId, IEnumerable<Materials> list, int quantity);
+    Task AddMaterialQuantity(string deviceAccountId, IEnumerable<Materials> list, int quantity);
+    Task AddMaterialQuantity(string deviceAccountId, Materials item, int quantity);
 }

--- a/DragaliaAPI.Database/Repositories/IStoryRepository.cs
+++ b/DragaliaAPI.Database/Repositories/IStoryRepository.cs
@@ -1,0 +1,15 @@
+﻿using DragaliaAPI.Database.Entities;
+using DragaliaAPI.Shared.Definitions.Enums;
+
+namespace DragaliaAPI.Database.Repositories;
+
+public interface IStoryRepository : IBaseRepository
+{
+    public IQueryable<DbPlayerStoryState> GetStoryList(string deviceAccountId);
+    public Task<DbPlayerStoryState> GetOrCreateStory(
+        string deviceAccountId,
+        StoryTypes storyType,
+        int storyId
+    );
+    Task UpdateStory(string deviceAccountId, StoryTypes storyType, int storyId, byte newState);
+}

--- a/DragaliaAPI.Database/Repositories/IUserDataRepository.cs
+++ b/DragaliaAPI.Database/Repositories/IUserDataRepository.cs
@@ -8,6 +8,7 @@ public interface IUserDataRepository : IBaseRepository
     Task<ISet<int>> GetTutorialFlags(string deviceAccountId);
     IQueryable<DbPlayerUserData> GetUserData(string deviceAccountId);
     IQueryable<DbPlayerUserData> GetUserData(long viewerId);
+    Task GiveWyrmite(string deviceAccountId, int quantity);
     Task SetMainPartyNo(string deviceAccountId, int partyNo);
     Task SetTutorialFlags(string deviceAccountId, ISet<int> tutorialFlags);
     Task SkipTutorial(string deviceAccountId);

--- a/DragaliaAPI.Database/Repositories/InventoryRepository.cs
+++ b/DragaliaAPI.Database/Repositories/InventoryRepository.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace DragaliaAPI.Database.Repositories;
 
+// TODO: add tests
 public class InventoryRepository : BaseRepository, IInventoryRepository
 {
     private readonly ApiContext apiContext;

--- a/DragaliaAPI.Database/Repositories/StoryRepository.cs
+++ b/DragaliaAPI.Database/Repositories/StoryRepository.cs
@@ -1,0 +1,70 @@
+﻿using DragaliaAPI.Database.Entities;
+using DragaliaAPI.Shared.Definitions.Enums;
+using Microsoft.EntityFrameworkCore;
+
+namespace DragaliaAPI.Database.Repositories;
+
+public class StoryRepository : BaseRepository, IStoryRepository
+{
+    private readonly ApiContext apiContext;
+
+    public StoryRepository(ApiContext apiContext) : base(apiContext)
+    {
+        this.apiContext = apiContext;
+    }
+
+    public IQueryable<DbPlayerStoryState> GetStoryList(string deviceAccountId)
+    {
+        return this.apiContext.PlayerStoryState.Where(x => x.DeviceAccountId == deviceAccountId);
+    }
+
+    public async Task<DbPlayerStoryState> GetOrCreateStory(
+        string deviceAccountId,
+        StoryTypes storyType,
+        int storyId
+    )
+    {
+        return await apiContext.PlayerStoryState.SingleOrDefaultAsync(
+                x => x.DeviceAccountId == deviceAccountId && x.StoryId == storyId
+            )
+            ?? apiContext.PlayerStoryState
+                .Add(
+                    new DbPlayerStoryState()
+                    {
+                        DeviceAccountId = deviceAccountId,
+                        StoryId = storyId,
+                        StoryType = storyType,
+                        State = 0
+                    }
+                )
+                .Entity;
+    }
+
+    public async Task UpdateStory(
+        string deviceAccountId,
+        StoryTypes storyType,
+        int storyId,
+        byte newState
+    )
+    {
+        // TODO: I don't think we should really add them if they don't exist as that may indicate not-unlocked.
+        // Need to research how to determine if story is accessible and implement API-side validation for this.
+        // Fine for now to trust the client.
+
+        DbPlayerStoryState story =
+            await apiContext.PlayerStoryState.FindAsync(deviceAccountId, storyType, storyId)
+            ?? apiContext.PlayerStoryState
+                .Add(
+                    new DbPlayerStoryState()
+                    {
+                        DeviceAccountId = deviceAccountId,
+                        StoryId = storyId,
+                        StoryType = storyType,
+                        State = newState
+                    }
+                )
+                .Entity;
+
+        story.State = newState;
+    }
+}

--- a/DragaliaAPI.Database/Repositories/UserDataRepository.cs
+++ b/DragaliaAPI.Database/Repositories/UserDataRepository.cs
@@ -94,6 +94,13 @@ public class UserDataRepository : BaseRepository, IUserDataRepository
         userData.LastSaveImportTime = DateTimeOffset.UtcNow;
     }
 
+    public async Task GiveWyrmite(string deviceAccountId, int quantity)
+    {
+        DbPlayerUserData userData = await this.LookupUserData(deviceAccountId);
+
+        userData.Crystal += quantity;
+    }
+
     private async Task<DbPlayerUserData> LookupUserData(string deviceAccountId)
     {
         return await apiContext.PlayerUserData.FindAsync(deviceAccountId)

--- a/DragaliaAPI.Test/Integration/Dragalia/CastleStoryTest.cs
+++ b/DragaliaAPI.Test/Integration/Dragalia/CastleStoryTest.cs
@@ -1,0 +1,121 @@
+﻿using DragaliaAPI.Database.Entities;
+using DragaliaAPI.Models.Generated;
+using DragaliaAPI.Shared.Definitions.Enums;
+using Microsoft.EntityFrameworkCore;
+
+namespace DragaliaAPI.Test.Integration.Dragalia;
+
+public class CastleStoryTest : IntegrationTestBase
+{
+    private readonly IntegrationTestFixture fixture;
+    private readonly HttpClient client;
+
+    public CastleStoryTest(IntegrationTestFixture fixture)
+    {
+        this.fixture = fixture;
+        this.client = fixture.CreateClient();
+    }
+
+    [Fact]
+    public async Task ReadStory_StoryNotRead_ResponseHasRewards()
+    {
+        CastleStoryReadData data = (
+            await this.client.PostMsgpack<CastleStoryReadData>(
+                "/castle_story/read",
+                new CastleStoryReadRequest() { castle_story_id = 1 }
+            )
+        ).data;
+
+        data.castle_story_reward_list
+            .Should()
+            .BeEquivalentTo(
+                new List<AtgenBuildEventRewardEntityList>()
+                {
+                    new()
+                    {
+                        entity_type = EntityTypes.Wyrmite,
+                        entity_quantity = 50,
+                        entity_id = 0
+                    }
+                }
+            );
+
+        data.update_data_list.user_data.Should().NotBeNull();
+        data.update_data_list.castle_story_list
+            .Should()
+            .BeEquivalentTo(
+                new List<CastleStoryList>()
+                {
+                    new() { castle_story_id = 1, is_read = 1, }
+                }
+            );
+    }
+
+    [Fact]
+    public async Task ReadStory_StoryRead_ResponseHasNoRewards()
+    {
+        this.fixture.ApiContext.Add(
+            new DbPlayerStoryState()
+            {
+                DeviceAccountId = this.fixture.DeviceAccountId,
+                State = 1,
+                StoryId = 2,
+                StoryType = StoryTypes.Castle
+            }
+        );
+        await this.fixture.ApiContext.SaveChangesAsync();
+
+        CastleStoryReadData data = (
+            await this.client.PostMsgpack<CastleStoryReadData>(
+                "/castle_story/read",
+                new CastleStoryReadRequest() { castle_story_id = 2 }
+            )
+        ).data;
+
+        data.castle_story_reward_list.Should().BeEmpty();
+
+        data.update_data_list.user_data.Should().BeNull();
+        data.update_data_list.unit_story_list.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ReadStory_StoryNotRead_UpdatesDatabase()
+    {
+        int oldCrystal = await this.fixture.ApiContext.PlayerUserData
+            .AsNoTracking()
+            .Where(x => x.DeviceAccountId == this.fixture.DeviceAccountId)
+            .Select(x => x.Crystal)
+            .SingleAsync();
+
+        CastleStoryReadData data = (
+            await this.client.PostMsgpack<CastleStoryReadData>(
+                "/castle_story/read",
+                new CastleStoryReadRequest() { castle_story_id = 3 }
+            )
+        ).data;
+
+        int newCrystal = await this.fixture.ApiContext.PlayerUserData
+            .AsNoTracking()
+            .Where(x => x.DeviceAccountId == this.fixture.DeviceAccountId)
+            .Select(x => x.Crystal)
+            .SingleAsync();
+
+        newCrystal.Should().Be(oldCrystal + 50);
+
+        IEnumerable<DbPlayerStoryState> stories = this.fixture.ApiContext.PlayerStoryState.Where(
+            x => x.DeviceAccountId == this.fixture.DeviceAccountId
+        );
+
+        stories
+            .Should()
+            .ContainEquivalentOf(
+                new DbPlayerStoryState()
+                {
+                    DeviceAccountId = this.fixture.DeviceAccountId,
+                    State = 1,
+                    StoryId = 3,
+                    StoryType = StoryTypes.Castle
+                }
+            );
+    }
+}

--- a/DragaliaAPI.Test/Integration/Dragalia/StoryTest.cs
+++ b/DragaliaAPI.Test/Integration/Dragalia/StoryTest.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DragaliaAPI.Database.Entities;
+using DragaliaAPI.Models.Generated;
+using DragaliaAPI.Shared.Definitions.Enums;
+using Microsoft.EntityFrameworkCore;
+
+namespace DragaliaAPI.Test.Integration.Dragalia;
+
+public class StoryTest : IntegrationTestBase
+{
+    private readonly IntegrationTestFixture fixture;
+    private readonly HttpClient client;
+
+    public StoryTest(IntegrationTestFixture fixture)
+    {
+        this.fixture = fixture;
+        this.client = fixture.CreateClient();
+    }
+
+    [Fact]
+    public async Task ReadStory_StoryNotRead_ResponseHasRewards()
+    {
+        StoryReadData data = (
+            await this.client.PostMsgpack<StoryReadData>(
+                "/story/read",
+                new StoryReadRequest() { unit_story_id = 1 }
+            )
+        ).data;
+
+        data.unit_story_reward_list
+            .Should()
+            .BeEquivalentTo(
+                new List<AtgenBuildEventRewardEntityList>()
+                {
+                    new()
+                    {
+                        entity_type = EntityTypes.Wyrmite,
+                        entity_quantity = 25,
+                        entity_id = 0
+                    }
+                }
+            );
+
+        data.update_data_list.user_data.Should().NotBeNull();
+        data.update_data_list.unit_story_list
+            .Should()
+            .BeEquivalentTo(
+                new List<UnitStoryList>()
+                {
+                    new() { unit_story_id = 1, is_read = 1, }
+                }
+            );
+    }
+
+    [Fact]
+    public async Task ReadStory_StoryRead_ResponseHasNoRewards()
+    {
+        this.fixture.ApiContext.Add(
+            new DbPlayerStoryState()
+            {
+                DeviceAccountId = this.fixture.DeviceAccountId,
+                State = 1,
+                StoryId = 2,
+                StoryType = StoryTypes.Chara
+            }
+        );
+        await this.fixture.ApiContext.SaveChangesAsync();
+
+        StoryReadData data = (
+            await this.client.PostMsgpack<StoryReadData>(
+                "/story/read",
+                new StoryReadRequest() { unit_story_id = 2 }
+            )
+        ).data;
+
+        data.unit_story_reward_list.Should().BeEmpty();
+
+        data.update_data_list.user_data.Should().BeNull();
+        data.update_data_list.unit_story_list.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ReadStory_StoryNotRead_UpdatesDatabase()
+    {
+        int oldCrystal = await this.fixture.ApiContext.PlayerUserData
+            .AsNoTracking()
+            .Where(x => x.DeviceAccountId == this.fixture.DeviceAccountId)
+            .Select(x => x.Crystal)
+            .SingleAsync();
+
+        StoryReadData data = (
+            await this.client.PostMsgpack<StoryReadData>(
+                "/story/read",
+                new StoryReadRequest() { unit_story_id = 3 }
+            )
+        ).data;
+
+        int newCrystal = await this.fixture.ApiContext.PlayerUserData
+            .AsNoTracking()
+            .Where(x => x.DeviceAccountId == this.fixture.DeviceAccountId)
+            .Select(x => x.Crystal)
+            .SingleAsync();
+
+        newCrystal.Should().Be(oldCrystal + 25);
+
+        IEnumerable<DbPlayerStoryState> stories = this.fixture.ApiContext.PlayerStoryState.Where(
+            x => x.DeviceAccountId == this.fixture.DeviceAccountId
+        );
+
+        stories
+            .Should()
+            .ContainEquivalentOf(
+                new DbPlayerStoryState()
+                {
+                    DeviceAccountId = this.fixture.DeviceAccountId,
+                    State = 1,
+                    StoryId = 3,
+                    StoryType = StoryTypes.Chara
+                }
+            );
+    }
+}

--- a/DragaliaAPI.Test/Unit/Controllers/DungeonRecordControllerTest.cs
+++ b/DragaliaAPI.Test/Unit/Controllers/DungeonRecordControllerTest.cs
@@ -76,7 +76,12 @@ public class DungeonRecordControllerTest
 
         this.mockInventoryRepository
             .Setup(
-                x => x.AddMaterials(DeviceAccountId, It.IsAny<List<Materials>>(), It.IsAny<int>())
+                x =>
+                    x.AddMaterialQuantity(
+                        DeviceAccountId,
+                        It.IsAny<List<Materials>>(),
+                        It.IsAny<int>()
+                    )
             )
             .Returns(Task.FromResult(0));
 

--- a/DragaliaAPI/Controllers/Dragalia/CastleStoryController.cs
+++ b/DragaliaAPI/Controllers/Dragalia/CastleStoryController.cs
@@ -1,0 +1,116 @@
+﻿using DragaliaAPI.Database.Repositories;
+using DragaliaAPI.Models;
+using DragaliaAPI.Models.Generated;
+using DragaliaAPI.Services;
+using DragaliaAPI.Services.Exceptions;
+using DragaliaAPI.Shared.Definitions.Enums;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace DragaliaAPI.Controllers.Dragalia;
+
+[Route("castle_story")]
+public class CastleStoryController : DragaliaControllerBase
+{
+    private readonly IStoryRepository storyRepository;
+    private readonly IUserDataRepository userDataRepository;
+    private readonly IInventoryRepository inventoryRepository;
+    private readonly IUpdateDataService updateDataService;
+    private readonly ILogger<CastleStoryController> logger;
+
+    private const int StoryWyrmiteReward = 50;
+
+    public CastleStoryController(
+        IStoryRepository storyRepository,
+        IUserDataRepository userDataRepository,
+        IInventoryRepository inventoryRepository,
+        IUpdateDataService updateDataService,
+        ILogger<CastleStoryController> logger
+    )
+    {
+        this.storyRepository = storyRepository;
+        this.userDataRepository = userDataRepository;
+        this.inventoryRepository = inventoryRepository;
+        this.updateDataService = updateDataService;
+        this.logger = logger;
+    }
+
+    [HttpPost("read")]
+    public async Task<DragaliaResult> Read(CastleStoryReadRequest request)
+    {
+        List<AtgenBuildEventRewardEntityList> rewardList = new(); // wtf is this type
+
+        if (
+            (
+                await this.storyRepository
+                    .GetStoryList(this.DeviceAccountId)
+                    .SingleOrDefaultAsync(
+                        x =>
+                            x.StoryType == StoryTypes.Castle && x.StoryId == request.castle_story_id
+                    )
+            )?.State != 1
+        )
+        {
+            int lookingGlassCount =
+                (
+                    await this.inventoryRepository.GetMaterial(
+                        this.DeviceAccountId,
+                        Materials.LookingGlass
+                    )
+                )?.Quantity ?? 0;
+
+            if (lookingGlassCount < 1)
+            {
+                throw new DragaliaException(
+                    ResultCode.CASTLE_STORY_OUT_OF_PERIOD,
+                    "Insufficient looking glasses"
+                );
+            }
+
+            await this.inventoryRepository.AddMaterialQuantity(
+                DeviceAccountId,
+                Materials.LookingGlass,
+                -1
+            );
+
+            this.logger.LogInformation(
+                "Reading previously unread story id {id}",
+                request.castle_story_id
+            );
+
+            await this.storyRepository.UpdateStory(
+                DeviceAccountId,
+                StoryTypes.Castle,
+                request.castle_story_id,
+                1
+            );
+
+            // TODO when giftbox is added: give rewards properly
+            // TODO: give different wyrmite rewards for chara/dragon stories
+            await this.userDataRepository.GiveWyrmite(this.DeviceAccountId, StoryWyrmiteReward);
+            rewardList.Add(
+                new()
+                {
+                    entity_type = EntityTypes.Wyrmite,
+                    entity_id = 0,
+                    entity_quantity = StoryWyrmiteReward
+                }
+            );
+        }
+
+        UpdateDataList updateDataList = this.updateDataService.GetUpdateDataList(
+            this.DeviceAccountId
+        );
+
+        await this.storyRepository.SaveChangesAsync();
+
+        return this.Ok(
+            new CastleStoryReadData()
+            {
+                castle_story_reward_list = rewardList,
+                update_data_list = updateDataList
+            }
+        );
+    }
+}

--- a/DragaliaAPI/Controllers/Dragalia/DungeonRecordController.cs
+++ b/DragaliaAPI/Controllers/Dragalia/DungeonRecordController.cs
@@ -87,7 +87,7 @@ public class DungeonRecordController : DragaliaControllerBase
             + (allMissionsCleared ? 5 : 0);
 
         IEnumerable<Materials> drops = DefaultDrops.GetRandomList();
-        await this.inventoryRepository.AddMaterials(this.DeviceAccountId, drops, 100);
+        await this.inventoryRepository.AddMaterialQuantity(this.DeviceAccountId, drops, 100);
 
         UpdateDataList updateDataList = this.updateDataService.GetUpdateDataList(
             this.DeviceAccountId

--- a/DragaliaAPI/Controllers/Dragalia/DungeonRecordController.cs
+++ b/DragaliaAPI/Controllers/Dragalia/DungeonRecordController.cs
@@ -312,6 +312,7 @@ public class DungeonRecordController : DragaliaControllerBase
             Materials.LongingHeart,
             // === Misc ===
             Materials.Omnicite,
+            Materials.LookingGlass,
         };
 
         public static IReadOnlyList<Materials> GetRandomList()

--- a/DragaliaAPI/Controllers/Dragalia/StoryController.cs
+++ b/DragaliaAPI/Controllers/Dragalia/StoryController.cs
@@ -1,0 +1,87 @@
+﻿using DragaliaAPI.Database.Repositories;
+using DragaliaAPI.Models.Generated;
+using DragaliaAPI.Services;
+using DragaliaAPI.Shared.Definitions.Enums;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace DragaliaAPI.Controllers.Dragalia;
+
+[Route("story")]
+public class StoryController : DragaliaControllerBase
+{
+    private readonly IStoryRepository storyRepository;
+    private readonly IUserDataRepository userDataRepository;
+    private readonly IUpdateDataService updateDataService;
+    private readonly ILogger<StoryController> logger;
+    private const int StoryWyrmiteReward = 25;
+
+    public StoryController(
+        IStoryRepository storyRepository,
+        IUserDataRepository userDataRepository,
+        IUpdateDataService updateDataService,
+        ILogger<StoryController> logger
+    )
+    {
+        this.storyRepository = storyRepository;
+        this.userDataRepository = userDataRepository;
+        this.updateDataService = updateDataService;
+        this.logger = logger;
+    }
+
+    [HttpPost("read")]
+    public async Task<DragaliaResult> Read(StoryReadRequest request)
+    {
+        List<AtgenBuildEventRewardEntityList> rewardList = new(); // wtf is this type
+
+        if (
+            (
+                await this.storyRepository
+                    .GetStoryList(this.DeviceAccountId)
+                    .SingleOrDefaultAsync(
+                        x => x.StoryType == StoryTypes.Chara && x.StoryId == request.unit_story_id
+                    )
+            )?.State != 1
+        )
+        {
+            this.logger.LogInformation(
+                "Reading previously unread story id {id}",
+                request.unit_story_id
+            );
+
+            await this.storyRepository.UpdateStory(
+                DeviceAccountId,
+                StoryTypes.Chara,
+                request.unit_story_id,
+                1
+            );
+
+            // TODO when giftbox is added: give rewards properly
+            // TODO: give different wyrmite rewards for chara/dragon stories
+            await this.userDataRepository.GiveWyrmite(this.DeviceAccountId, StoryWyrmiteReward);
+            rewardList.Add(
+                new()
+                {
+                    entity_type = EntityTypes.Wyrmite,
+                    entity_id = 0,
+                    entity_quantity = StoryWyrmiteReward
+                }
+            );
+        }
+
+        UpdateDataList updateDataList = this.updateDataService.GetUpdateDataList(
+            this.DeviceAccountId
+        );
+
+        await this.storyRepository.SaveChangesAsync();
+
+        return this.Ok(
+            new StoryReadData()
+            {
+                unit_story_reward_list = rewardList,
+                update_data_list = updateDataList
+            }
+        );
+    }
+}

--- a/DragaliaAPI/Services/SavefileService.cs
+++ b/DragaliaAPI/Services/SavefileService.cs
@@ -248,7 +248,7 @@ public class SavefileService : ISavefileService
         await this.apiContext.SaveChangesAsync();
     }
 
-    #region Default save data
+	#region Default save data
     private async Task AddDefaultParties(string deviceAccountId)
     {
         await this.apiContext.PlayerParties.AddRangeAsync(
@@ -581,8 +581,9 @@ public class SavefileService : ISavefileService
         {
             Materials.GoldCrystal,
             Materials.SilverCrystal,
-            Materials.BronzeCrystal
+            Materials.BronzeCrystal,
+            Materials.LookingGlass
         };
     }
-    #endregion
+	#endregion
 }


### PR DESCRIPTION
- Adds endpoints for unit and castle stories
- These currently add 25/50 wyrmite directly but will need to be updated later to use the gift box
- Castle stories deduct looking glasses; give new savefiles 100 of these and add to quest drop table to enable testing
- Currently no API validation on story availability