### PR TITLE
Add response compression

### DIFF
--- a/DragaliaAPI/Program.cs
+++ b/DragaliaAPI/Program.cs
@@ -69,6 +69,7 @@ builder.Services.AddAuthentication(opts =>
 });
 
 builder.Services
+    .AddResponseCompression()
     .ConfigureDatabaseServices(builder.Configuration.GetConnectionString("PostgresHost"))
     .AddAutoMapper(Assembly.GetExecutingAssembly())
     .AddStackExchangeRedisCache(options =>
@@ -124,6 +125,7 @@ app.UseRouting();
 app.UseAuthentication();
 app.UseAuthorization();
 app.MapControllers();
+app.UseResponseCompression();
 app.MapHealthChecks("/health");
 
 app.UseMiddleware<ExceptionHandlerMiddleware>();


### PR DESCRIPTION
Quick change to add compression to responses, which appears to work and should make latency a bit better.

Not likely to solve #88 as that timing window is request processing and has nothing to do with the transit time that this will affect.