### PR TITLE
Wyrmprint fix + misc tweaks

### DIFF
--- a/DragaliaAPI.Test/Integration/Other/SavefileImportTest.cs
+++ b/DragaliaAPI.Test/Integration/Other/SavefileImportTest.cs
@@ -2,6 +2,7 @@
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using DragaliaAPI.MessagePack;
 using DragaliaAPI.Models;
 using DragaliaAPI.Models.Generated;
@@ -95,6 +96,11 @@ public class SavefileImportTest : IClassFixture<IntegrationTestFixture>
                     opts.Excluding(x => x.user_data.viewer_id);
                     opts.Excluding(x => x.server_time);
                     opts.Excluding(x => x.spec_upgrade_time);
+                    opts.Excluding(
+                        x =>
+                            x.Path.StartsWith("ability_crest_list")
+                            && (x.Name == "ability_1_level" || x.Name == "ability_2_level")
+                    );
 
                     // Ignored properties
                     opts.Excluding(x => x.user_data.prologue_end_time);

--- a/DragaliaAPI/Models/AutoMapper/UnitMapProfile.cs
+++ b/DragaliaAPI/Models/AutoMapper/UnitMapProfile.cs
@@ -25,12 +25,12 @@ public class UnitMapProfile : Profile
             );
 
         this.CreateMap<DbAbilityCrest, AbilityCrestList>()
-            .ForMember(x => x.ability_1_level, opts => opts.Ignore())
-            .ForMember(x => x.ability_2_level, opts => opts.Ignore());
+            .ForMember(x => x.ability_1_level, opts => opts.MapFrom(x => 3))
+            .ForMember(x => x.ability_2_level, opts => opts.MapFrom(x => 3));
 
         this.CreateMap<DbAbilityCrest, GameAbilityCrest>()
-            .ForMember(x => x.ability_1_level, opts => opts.Ignore())
-            .ForMember(x => x.ability_2_level, opts => opts.Ignore());
+            .ForMember(x => x.ability_1_level, opts => opts.MapFrom(x => 3))
+            .ForMember(x => x.ability_2_level, opts => opts.MapFrom(x => 3));
 
         this.CreateMap<DbWeaponBody, WeaponBodyList>()
             .ForMember(x => x.ability_1_level, opts => opts.Ignore())

--- a/DragaliaAPI/Pages/News.cshtml
+++ b/DragaliaAPI/Pages/News.cshtml
@@ -33,21 +33,20 @@
 	<ul>
 		<li>The tutorial up until halfway through Ch. 1</li>
 		<li>Editing parties</li>
-		<li>Most boss fights and main story quests</li>
+		<li>Most boss fights and main story quests<sup>1</sup></li>
 		<li>Summoning</li>
 		<li>Upgrading characters and their mana circles</li>
+		<li>Unit and dragon stories<sup>2</sup></li>
 	</ul>
-	<p>*All halidom boosts are set to 200%, and every quest has 3 continues and retries, so the difficulty isn't the same.</p>
+	<p><sup>1</sup>All halidom boosts are set to 200%, and every quest has 3 continues and retries, so the difficulty isn't the same.</p>
+	<p><sup>2</sup>These cannot be manually unlocked and can only be made accessible by importing a save.</p>
 
 	<h2>What does not work</h2>
 	<ul>
-		<li>Helpers</li>
 		<li>Quest drops</li>
 		<li>Upgrading dragons and weapons</li>
 		<li>Events and event compendium</li>
 		<li>Co-op, including battle royale and raids</li>
-		<li>The Halidom and related functionality (e.g. Dragon's Roost)</li>
-		<li>Unit/dragon stories</li>
 		<li>Endeavours</li>
 		<li>Kaleidoscape</li>
 		<li>The Mercurial Gauntlet</li>

--- a/DragaliaAPI/Services/AuthService.cs
+++ b/DragaliaAPI/Services/AuthService.cs
@@ -1,5 +1,6 @@
 ﻿using DragaliaAPI.Database.Entities;
 using DragaliaAPI.Database.Repositories;
+using DragaliaAPI.Middleware;
 using DragaliaAPI.Models.Generated;
 using DragaliaAPI.Models.Options;
 using DragaliaAPI.Services.Exceptions;
@@ -10,6 +11,7 @@ using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.Tokens;
 using Newtonsoft.Json;
 using Serilog;
+using Serilog.Context;
 using System.IdentityModel.Tokens.Jwt;
 
 namespace DragaliaAPI.Services;
@@ -83,31 +85,34 @@ public class AuthService : IAuthService
         TokenValidationResult result = await this.ValidateToken(idToken);
         JwtSecurityToken jwt = (JwtSecurityToken)result.SecurityToken;
 
-        if (
-            GetPendingSaveImport(
-                jwt,
-                await this.userDataRepository.GetUserData(jwt.Subject).SingleOrDefaultAsync()
-            )
-        )
+        using (LogContext.PushProperty(CustomClaimType.AccountId, jwt.Subject))
         {
-            try
+            if (
+                GetPendingSaveImport(
+                    jwt,
+                    await this.userDataRepository.GetUserData(jwt.Subject).SingleOrDefaultAsync()
+                )
+            )
             {
-                LoadIndexData pendingSave = await this.baasRequestHelper.GetSavefile(idToken);
-                await this.savefileService.Import(jwt.Subject, pendingSave);
-                await this.userDataRepository.UpdateSaveImportTime(jwt.Subject);
-                await this.userDataRepository.SaveChangesAsync();
+                try
+                {
+                    LoadIndexData pendingSave = await this.baasRequestHelper.GetSavefile(idToken);
+                    await this.savefileService.Import(jwt.Subject, pendingSave);
+                    await this.userDataRepository.UpdateSaveImportTime(jwt.Subject);
+                    await this.userDataRepository.SaveChangesAsync();
+                }
+                catch (Exception e)
+                {
+                    this.logger.LogError("Error importing save", e);
+                    // Let them log in regardless
+                }
             }
-            catch (Exception e)
-            {
-                this.logger.LogError(e, "Error importing save");
-                // Let them log in regardless
-            }
+
+            long viewerId = await this.DoLogin(jwt.Subject);
+            string sessionId = await this.sessionService.CreateSession(jwt.Subject, idToken);
+
+            return new(viewerId, sessionId);
         }
-
-        long viewerId = await this.DoLogin(jwt.Subject);
-        string sessionId = await this.sessionService.CreateSession(jwt.Subject, idToken);
-
-        return new(viewerId, sessionId);
     }
 
     private async Task<TokenValidationResult> ValidateToken(string idToken)

--- a/DragaliaAPI/appsettings.Testing.json
+++ b/DragaliaAPI/appsettings.Testing.json
@@ -1,12 +1,6 @@
 {
     "Serilog": {
-        "MinimumLevel": {
-            "Default": "Information",
-            "Override": {
-                "Microsoft.AspNetCore": "Warning",
-                "Microsoft.EntityFrameworkCore": "Warning"
-            }
-        }
+        "MinimumLevel": "Fatal"
     },
     // Ensure consistent config value in test
     "Login": {


### PR DESCRIPTION
- Auto-set wyrmprints abilities as level 3; closes #78. Issue #96 raised to do this properly later.
- Update news page
- Add an enrich statement to AuthService to include the account id, enabling this to be logged for the first login where the SessionLookupMiddleware has not been used