### PR TITLE
Add viewer id to logs

### DIFF
--- a/DragaliaAPI.Database/Repositories/IUnitRepository.cs
+++ b/DragaliaAPI.Database/Repositories/IUnitRepository.cs
@@ -21,7 +21,7 @@ public interface IUnitRepository : IBaseRepository
     Task<DbSetUnit?> GetCharaSetData(string deviceAccountId, Charas charaId, int setNo);
     DbSetUnit AddCharaSetData(string deviceAccountId, Charas charaId, int setNo);
     IEnumerable<DbSetUnit> GetCharaSets(string deviceAccountId, Charas charaId);
-    IDictionary<Charas, IEnumerable<DbSetUnit>> GetCharaSets(
+    Task<IDictionary<Charas, IEnumerable<DbSetUnit>>> GetCharaSets(
         string deviceAccountId,
         IEnumerable<Charas> charaId
     );

--- a/DragaliaAPI.Database/Repositories/UnitRepository.cs
+++ b/DragaliaAPI.Database/Repositories/UnitRepository.cs
@@ -179,15 +179,15 @@ public class UnitRepository : BaseRepository, IUnitRepository
         );
     }
 
-    public IDictionary<Charas, IEnumerable<DbSetUnit>> GetCharaSets(
+    public async Task<IDictionary<Charas, IEnumerable<DbSetUnit>>> GetCharaSets(
         string deviceAccountId,
         IEnumerable<Charas> charaIds
     )
     {
-        return apiContext.PlayerSetUnits
+        return await apiContext.PlayerSetUnits
             .Where(x => charaIds.Contains(x.CharaId))
             .GroupBy(x => x.CharaId)
-            .ToDictionary(x => x.Key, x => x.AsEnumerable());
+            .ToDictionaryAsync(x => x.Key, x => x.AsEnumerable());
     }
 
     private static IEnumerable<(TEnum id, bool isNew)> MarkNewIds<TEnum>(

--- a/DragaliaAPI.Test/TestUtils.cs
+++ b/DragaliaAPI.Test/TestUtils.cs
@@ -123,6 +123,11 @@ public static class TestUtils
     public const string DeviceAccountId = "id";
 
     /// <summary>
+    /// Same for ViewerId.
+    /// </summary>
+    public const int ViewerId = 1;
+
+    /// <summary>
     /// Cast the data of a <see cref="ActionResult{DragaliaResponse}"/> to a given type.
     /// <remarks>Uses 'as' casting, and will return null if the cast failed.</remarks>
     /// </summary>
@@ -202,7 +207,11 @@ public static class TestUtils
             {
                 User = new(
                     new ClaimsIdentity(
-                        new List<Claim>() { new Claim(CustomClaimType.AccountId, DeviceAccountId) }
+                        new List<Claim>()
+                        {
+                            new Claim(CustomClaimType.AccountId, DeviceAccountId),
+                            new Claim(CustomClaimType.ViewerId, ViewerId.ToString())
+                        }
                     )
                 )
             }

--- a/DragaliaAPI.Test/Unit/Controllers/DungeonStartControllerTest.cs
+++ b/DragaliaAPI.Test/Unit/Controllers/DungeonStartControllerTest.cs
@@ -67,18 +67,6 @@ public class DungeonStartControllerTest
                 }
             );
 
-        this.mockUserDataRepository
-            .Setup(x => x.GetUserData(DeviceAccountId))
-            .Returns(new List<DbPlayerUserData>()
-                {
-                    new()
-                    {
-                        DeviceAccountId = DeviceAccountId,
-                        Name = "Euden",
-                        ViewerId = 1
-                    }
-                }.AsQueryable().BuildMock());
-
         /* this.mockPartyRepository
              .Setup(x => x.Get(DeviceAccountId))
              .Returns(new List<DbParty>()

--- a/DragaliaAPI.Test/Unit/Services/AuthServiceTest.cs
+++ b/DragaliaAPI.Test/Unit/Services/AuthServiceTest.cs
@@ -65,8 +65,8 @@ public class AuthServiceTest
             .Setup(x => x.ActivateSession("id token"))
             .ReturnsAsync("session id");
         this.mockSessionService
-            .Setup(x => x.GetDeviceAccountId_SessionId("session id"))
-            .ReturnsAsync("device account id");
+            .Setup(x => x.LoadSessionSessionId("session id"))
+            .ReturnsAsync(new Session("session id", "token", "device account id", 1));
         this.mockUserDataRepository
             .Setup(x => x.GetUserData("device account id"))
             .Returns(new List<DbPlayerUserData>()
@@ -109,7 +109,7 @@ public class AuthServiceTest
                     new() { DeviceAccountId = "id", ViewerId = 1 }
                 }.AsQueryable().BuildMock());
         this.mockSessionService
-            .Setup(x => x.CreateSession(AccountId, token))
+            .Setup(x => x.CreateSession(AccountId, token, 1))
             .ReturnsAsync("session id");
 
         (await this.authService.DoAuth(token)).Should().BeEquivalentTo((1, "session id"));
@@ -221,7 +221,7 @@ public class AuthServiceTest
         this.mockUserDataRepository.Setup(x => x.SaveChangesAsync()).ReturnsAsync(1);
 
         this.mockSessionService
-            .Setup(x => x.CreateSession(AccountId, token))
+            .Setup(x => x.CreateSession(AccountId, token, 1))
             .ReturnsAsync("session id");
 
         this.mockSavefileService
@@ -280,7 +280,7 @@ public class AuthServiceTest
                 }.AsQueryable().BuildMock());
 
         this.mockSessionService
-            .Setup(x => x.CreateSession(AccountId, token))
+            .Setup(x => x.CreateSession(AccountId, token, 1))
             .ReturnsAsync("session id");
 
         await this.authService.Invoking(x => x.DoAuth(token)).Should().NotThrowAsync();
@@ -330,7 +330,7 @@ public class AuthServiceTest
                 }.AsQueryable().BuildMock());
 
         this.mockSessionService
-            .Setup(x => x.CreateSession(AccountId, token))
+            .Setup(x => x.CreateSession(AccountId, token, 1))
             .ReturnsAsync("session id");
 
         await this.authService.DoAuth(token);
@@ -384,7 +384,7 @@ public class AuthServiceTest
                 }.AsQueryable().BuildMock());
 
         this.mockSessionService
-            .Setup(x => x.CreateSession(AccountId, token))
+            .Setup(x => x.CreateSession(AccountId, token, 1))
             .ReturnsAsync("session id");
 
         await this.authService.DoAuth(token);

--- a/DragaliaAPI.Test/Unit/Services/DungeonServiceTest.cs
+++ b/DragaliaAPI.Test/Unit/Services/DungeonServiceTest.cs
@@ -1,5 +1,6 @@
 ﻿using DragaliaAPI.Models;
 using DragaliaAPI.Models.Generated;
+using DragaliaAPI.Models.Options;
 using DragaliaAPI.Services;
 using DragaliaAPI.Services.Exceptions;
 using DragaliaAPI.Shared.Definitions;
@@ -13,23 +14,23 @@ namespace DragaliaAPI.Test.Unit.Services;
 
 public class DungeonServiceTest
 {
+    private readonly Mock<IOptionsMonitor<RedisOptions>> mockOptions;
     private readonly IDungeonService dungeonService;
 
     public DungeonServiceTest()
     {
+        mockOptions = new(MockBehavior.Strict);
+
         IOptions<MemoryDistributedCacheOptions> opts = Options.Create(
             new MemoryDistributedCacheOptions()
         );
         IDistributedCache testCache = new MemoryDistributedCache(opts);
 
-        Dictionary<string, string?> inMemoryConfiguration =
-            new() { { "DungeonExpiryTimeMinutes", "5" }, };
+        this.mockOptions
+            .SetupGet(x => x.CurrentValue)
+            .Returns(new RedisOptions() { DungeonExpiryTimeMinutes = 1 });
 
-        IConfiguration configuration = new ConfigurationBuilder()
-            .AddInMemoryCollection(inMemoryConfiguration)
-            .Build();
-
-        dungeonService = new DungeonService(testCache, configuration);
+        dungeonService = new DungeonService(testCache, mockOptions.Object);
     }
 
     [Fact]

--- a/DragaliaAPI/Controllers/Dragalia/CharaController.cs
+++ b/DragaliaAPI/Controllers/Dragalia/CharaController.cs
@@ -746,7 +746,7 @@ public class CharaController : DragaliaControllerBase
         [FromBody] CharaGetCharaUnitSetRequest request
     )
     {
-        IDictionary<Charas, IEnumerable<DbSetUnit>> setUnitData = unitRepository.GetCharaSets(
+        IDictionary<Charas, IEnumerable<DbSetUnit>> setUnitData = await unitRepository.GetCharaSets(
             DeviceAccountId,
             request.chara_id_list.Select(x => (Charas)x)
         );

--- a/DragaliaAPI/Controllers/Dragalia/DungeonStartController.cs
+++ b/DragaliaAPI/Controllers/Dragalia/DungeonStartController.cs
@@ -116,8 +116,6 @@ public class DungeonStartController : DragaliaControllerBase
 
         this.logger.LogInformation("{time} ms: Built party", stopwatch.ElapsedMilliseconds);
 
-        this.logger.LogInformation("{time} ms: Viewer ID looked up", stopwatch.ElapsedMilliseconds);
-
         QuestData questInfo = MasterAsset.QuestData.Get(request.quest_id);
 
         /*IEnumerable<int> enemyList = this.enemyListDataService

--- a/DragaliaAPI/Controllers/Dragalia/DungeonStartController.cs
+++ b/DragaliaAPI/Controllers/Dragalia/DungeonStartController.cs
@@ -116,11 +116,6 @@ public class DungeonStartController : DragaliaControllerBase
 
         this.logger.LogInformation("{time} ms: Built party", stopwatch.ElapsedMilliseconds);
 
-        long viewerId = await this.userDataRepository
-            .GetUserData(this.DeviceAccountId)
-            .Select(x => x.ViewerId)
-            .SingleAsync();
-
         this.logger.LogInformation("{time} ms: Viewer ID looked up", stopwatch.ElapsedMilliseconds);
 
         QuestData questInfo = MasterAsset.QuestData.Get(request.quest_id);
@@ -153,7 +148,7 @@ public class DungeonStartController : DragaliaControllerBase
             {
                 ingame_data = new()
                 {
-                    viewer_id = (ulong)viewerId,
+                    viewer_id = (ulong)this.ViewerId,
                     dungeon_key = dungeonKey,
                     dungeon_type = questInfo.DungeonType,
                     play_type = questInfo.QuestPlayModeType,

--- a/DragaliaAPI/Controllers/Dragalia/RedoableSummonController.cs
+++ b/DragaliaAPI/Controllers/Dragalia/RedoableSummonController.cs
@@ -127,7 +127,11 @@ public class RedoableSummonController : DragaliaControllerBase
 
         await cache.SetStringAsync(
             Schema.SessionId_CachedSummonResult(sessionId),
-            JsonSerializer.Serialize(summonResult)
+            JsonSerializer.Serialize(summonResult),
+            new DistributedCacheEntryOptions()
+            {
+                AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(60)
+            }
         );
 
         return this.Ok(new RedoableSummonPreExecData(new UserRedoableSummonData(1, summonResult)));

--- a/DragaliaAPI/Controllers/Dragalia/SummonController.cs
+++ b/DragaliaAPI/Controllers/Dragalia/SummonController.cs
@@ -25,7 +25,6 @@ public class SummonController : DragaliaControllerBase
     private readonly IUpdateDataService updateDataService;
     private readonly IMapper mapper;
     private readonly ISummonRepository summonRepository;
-    private readonly ISessionService _sessionService;
     private readonly ISummonService _summonService;
 
     // Repeated from RedoableSummonController, but no point putting this in a shared location
@@ -136,7 +135,6 @@ public class SummonController : DragaliaControllerBase
         IUpdateDataService updateDataService,
         IMapper mapper,
         ISummonRepository summonRepository,
-        ISessionService sessionService,
         ISummonService summonService
     )
     {
@@ -145,7 +143,6 @@ public class SummonController : DragaliaControllerBase
         this.updateDataService = updateDataService;
         this.mapper = mapper;
         this.summonRepository = summonRepository;
-        _sessionService = sessionService;
         _summonService = summonService;
     }
 
@@ -212,30 +209,22 @@ public class SummonController : DragaliaControllerBase
 
     [HttpPost]
     [Route("get_summon_list")]
-    public async Task<DragaliaResult> GetSummonList([FromHeader(Name = "SID")] string sessionId)
+    public async Task<DragaliaResult> GetSummonList()
     {
-        string accountId = await _sessionService.GetDeviceAccountId_SessionId(sessionId);
-
-        // PS nano I removed all the DB stuff because I was too lazy to make it work again
-
         return Ok(Data.SummonListData);
     }
 
     [HttpPost]
     [Route("get_summon_point_trade")]
-    public async Task<DragaliaResult> GetSummonPointTrade(
-        [FromHeader(Name = "SID")] string sessionId,
-        SummonGetSummonPointTradeRequest request
-    )
+    public async Task<DragaliaResult> GetSummonPointTrade(SummonGetSummonPointTradeRequest request)
     {
         int bannerId = request.summon_id;
-        string accountId = await _sessionService.GetDeviceAccountId_SessionId(sessionId);
         DbPlayerUserData userData = await this.userDataRepository
-            .GetUserData(accountId)
+            .GetUserData(DeviceAccountId)
             .FirstAsync();
         //TODO maybe throw BadRequest on bad banner id, for now generate empty data if not exists
         DbPlayerBannerData playerBannerData = await this.summonRepository.GetPlayerBannerData(
-            accountId,
+            DeviceAccountId,
             bannerId
         );
         //TODO get real list from persisted BannerInfo or dynamic List from Db, dunno yet

--- a/DragaliaAPI/Controllers/DragaliaControllerBase.cs
+++ b/DragaliaAPI/Controllers/DragaliaControllerBase.cs
@@ -17,6 +17,12 @@ public abstract class DragaliaControllerBase : ControllerBase
         this.User.FindFirstValue(CustomClaimType.AccountId)
         ?? throw new InvalidOperationException("No AccountId claim value found");
 
+    protected long ViewerId =>
+        long.Parse(
+            this.User.FindFirstValue(CustomClaimType.ViewerId)
+                ?? throw new InvalidOperationException("No ViewerId claim value found")
+        );
+
     public override OkObjectResult Ok(object? value)
     {
         return base.Ok(

--- a/DragaliaAPI/Controllers/Nintendo/NintendoLoginController.cs
+++ b/DragaliaAPI/Controllers/Nintendo/NintendoLoginController.cs
@@ -76,7 +76,8 @@ public class NintendoLoginController : ControllerBase
         await this.sessionService.PrepareSession(deviceAccount, token);
 
         TimeSpan reloginTime =
-            TimeSpan.FromMinutes(this.configuration.GetValue<int>("SessionExpiryTimeMinutes")) / 2;
+            TimeSpan.FromMinutes(this.configuration.GetValue<int>("Redis:SessionExpiryTimeMinutes"))
+            / 2;
 
         LoginResponse response =
             new(token, deviceAccount, (int)reloginTime.TotalSeconds)

--- a/DragaliaAPI/GlobalSuppressions.cs
+++ b/DragaliaAPI/GlobalSuppressions.cs
@@ -8,5 +8,7 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage(
     "Style",
     "IDE1006:Naming Styles",
+    Scope = "namespaceanddescendants",
+    Target = "~N:DragaliaAPI.Models.Generated",
     Justification = "msgpack/json object fields should start with lowercase to match real keys"
 )]

--- a/DragaliaAPI/Middleware/AccountIdEnricher.cs
+++ b/DragaliaAPI/Middleware/AccountIdEnricher.cs
@@ -28,5 +28,18 @@ public class AccountIdEnricher : ILogEventEnricher
             );
             logEvent.AddPropertyIfAbsent(property);
         }
+
+        string? viewerId = contextAccessor.HttpContext?.User.FindFirstValue(
+            CustomClaimType.ViewerId
+        );
+
+        if (!string.IsNullOrEmpty(viewerId))
+        {
+            LogEventProperty property = propertyFactory.CreateProperty(
+                CustomClaimType.ViewerId,
+                viewerId
+            );
+            logEvent.AddPropertyIfAbsent(property);
+        }
     }
 }

--- a/DragaliaAPI/Middleware/CustomClaimType.cs
+++ b/DragaliaAPI/Middleware/CustomClaimType.cs
@@ -9,4 +9,9 @@ public static class CustomClaimType
     /// Primary key; BaaS ID / DeviceAccountId
     /// </summary>
     public const string AccountId = "AccountId";
+
+    /// <summary>
+    /// Viewer ID; publically facing 'friend request' ID
+    /// </summary>
+    public const string ViewerId = "ViewerId";
 }

--- a/DragaliaAPI/Middleware/SessionAuthenticationHandler.cs
+++ b/DragaliaAPI/Middleware/SessionAuthenticationHandler.cs
@@ -40,9 +40,13 @@ public class SessionAuthenticationHandler : AuthenticationHandler<Authentication
             return AuthenticateResult.Fail("Invalid SID header: value was null");
 
         // This will throw SessionException if not found, and return a BadRequest which prompts the client to re-login
-        string id = await sessionService.GetDeviceAccountId_SessionId(sid);
+        Session session = await this.sessionService.LoadSessionSessionId(sid);
 
-        Claim[] claims = new[] { new Claim(CustomClaimType.AccountId, id) };
+        Claim[] claims = new[]
+        {
+            new Claim(CustomClaimType.AccountId, session.DeviceAccountId),
+            new Claim(CustomClaimType.ViewerId, session.ViewerId.ToString())
+        };
         ClaimsIdentity identity = new(claims, this.Scheme.Name);
         ClaimsPrincipal principal = new(identity);
         AuthenticationTicket ticket = new(principal, this.Scheme.Name);

--- a/DragaliaAPI/Models/Options/RedisOptions.cs
+++ b/DragaliaAPI/Models/Options/RedisOptions.cs
@@ -1,0 +1,7 @@
+﻿namespace DragaliaAPI.Models.Options;
+
+public class RedisOptions
+{
+    public int SessionExpiryTimeMinutes { get; set; }
+    public int DungeonExpiryTimeMinutes { get; set; }
+}

--- a/DragaliaAPI/Models/Session.cs
+++ b/DragaliaAPI/Models/Session.cs
@@ -1,0 +1,3 @@
+﻿namespace DragaliaAPI.Services;
+
+public record Session(string SessionId, string IdToken, string DeviceAccountId, long ViewerId);

--- a/DragaliaAPI/Program.cs
+++ b/DragaliaAPI/Program.cs
@@ -23,9 +23,11 @@ Log.Logger = new LoggerConfiguration().MinimumLevel
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
 ConfigurationManager configuration = builder.Configuration;
-builder.Services.Configure<BaasOptions>(configuration.GetRequiredSection("Baas"));
-builder.Services.Configure<LoginOptions>(configuration.GetRequiredSection("Login"));
-builder.Services.Configure<DragalipatchOptions>(configuration.GetRequiredSection("Dragalipatch"));
+builder.Services
+    .Configure<BaasOptions>(configuration.GetRequiredSection("Baas"))
+    .Configure<LoginOptions>(configuration.GetRequiredSection("Login"))
+    .Configure<DragalipatchOptions>(configuration.GetRequiredSection("Dragalipatch"))
+    .Configure<RedisOptions>(configuration.GetRequiredSection("Redis"));
 
 builder.Logging.ClearProviders();
 builder.Logging.AddSerilog();

--- a/DragaliaAPI/Program.cs
+++ b/DragaliaAPI/Program.cs
@@ -101,7 +101,7 @@ app.UseSerilogRequestLogging(
         options.EnrichDiagnosticContext = (diagContext, httpContext) =>
             diagContext.Set(
                 CustomClaimType.AccountId,
-                httpContext.User.FindFirstValue(CustomClaimType.AccountId) ?? "anonymous"
+                httpContext.User.FindFirstValue(CustomClaimType.AccountId)
             )
 );
 

--- a/DragaliaAPI/Services/AuthService.cs
+++ b/DragaliaAPI/Services/AuthService.cs
@@ -71,7 +71,9 @@ public class AuthService : IAuthService
         string deviceAccountId;
 
         sessionId = await this.sessionService.ActivateSession(idToken);
-        deviceAccountId = await this.sessionService.GetDeviceAccountId_SessionId(sessionId);
+        deviceAccountId = (
+            await this.sessionService.LoadSessionSessionId(sessionId)
+        ).DeviceAccountId;
 
         IQueryable<DbPlayerUserData> playerInfo = this.userDataRepository.GetUserData(
             deviceAccountId
@@ -109,7 +111,11 @@ public class AuthService : IAuthService
             }
 
             long viewerId = await this.DoLogin(jwt.Subject);
-            string sessionId = await this.sessionService.CreateSession(jwt.Subject, idToken);
+            string sessionId = await this.sessionService.CreateSession(
+                jwt.Subject,
+                idToken,
+                viewerId
+            );
 
             return new(viewerId, sessionId);
         }

--- a/DragaliaAPI/Services/AuthService.cs
+++ b/DragaliaAPI/Services/AuthService.cs
@@ -54,13 +54,6 @@ public class AuthService : IAuthService
             : await this.DoLegacyAuth(idToken);
 #pragma warning restore CS0618 // Type or member is obsolete
 
-        this.logger.LogInformation(
-            "Authenticated user with viewer ID {viewerid} using token ...{token} and issued session ID {sid}",
-            result.viewerId,
-            idToken[^5..],
-            result.sessionId
-        );
-
         return result;
     }
 
@@ -87,38 +80,44 @@ public class AuthService : IAuthService
         TokenValidationResult result = await this.ValidateToken(idToken);
         JwtSecurityToken jwt = (JwtSecurityToken)result.SecurityToken;
 
-        using (LogContext.PushProperty(CustomClaimType.AccountId, jwt.Subject))
-        {
-            if (
-                GetPendingSaveImport(
-                    jwt,
-                    await this.userDataRepository.GetUserData(jwt.Subject).SingleOrDefaultAsync()
-                )
+        using IDisposable accIdLog = LogContext.PushProperty(
+            CustomClaimType.AccountId,
+            jwt.Subject
+        );
+
+        if (
+            GetPendingSaveImport(
+                jwt,
+                await this.userDataRepository.GetUserData(jwt.Subject).SingleOrDefaultAsync()
             )
+        )
+        {
+            try
             {
-                try
-                {
-                    LoadIndexData pendingSave = await this.baasRequestHelper.GetSavefile(idToken);
-                    await this.savefileService.Import(jwt.Subject, pendingSave);
-                    await this.userDataRepository.UpdateSaveImportTime(jwt.Subject);
-                    await this.userDataRepository.SaveChangesAsync();
-                }
-                catch (Exception e)
-                {
-                    this.logger.LogError(e, "Error importing save");
-                    // Let them log in regardless
-                }
+                LoadIndexData pendingSave = await this.baasRequestHelper.GetSavefile(idToken);
+                await this.savefileService.Import(jwt.Subject, pendingSave);
+                await this.userDataRepository.UpdateSaveImportTime(jwt.Subject);
+                await this.userDataRepository.SaveChangesAsync();
             }
-
-            long viewerId = await this.DoLogin(jwt.Subject);
-            string sessionId = await this.sessionService.CreateSession(
-                jwt.Subject,
-                idToken,
-                viewerId
-            );
-
-            return new(viewerId, sessionId);
+            catch (Exception e)
+            {
+                this.logger.LogError(e, "Error importing save");
+                // Let them log in regardless
+            }
         }
+
+        long viewerId = await this.DoLogin(jwt.Subject);
+        string sessionId = await this.sessionService.CreateSession(jwt.Subject, idToken, viewerId);
+
+        using IDisposable vIdLog = LogContext.PushProperty(CustomClaimType.ViewerId, viewerId);
+
+        this.logger.LogInformation(
+            "Authenticated user with viewer ID {viewerid} and issued session ID {sid}",
+            viewerId,
+            sessionId
+        );
+
+        return new(viewerId, sessionId);
     }
 
     private async Task<TokenValidationResult> ValidateToken(string idToken)

--- a/DragaliaAPI/Services/DungeonService.cs
+++ b/DragaliaAPI/Services/DungeonService.cs
@@ -1,6 +1,7 @@
 ﻿using DragaliaAPI.Models;
 using DragaliaAPI.Models.Options;
 using DragaliaAPI.Services.Exceptions;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Options;
 using System.Text.Json;
@@ -19,10 +20,7 @@ public class DungeonService : IDungeonService
 
     private static class Schema
     {
-        public static string DungeonKey_DungeonData(string dungeonKey)
-        {
-            return $":dungeon:{dungeonKey}";
-        }
+        public static string DungeonKey_DungeonData(string dungeonKey) => $":dungeon:{dungeonKey}";
     }
 
     public DungeonService(IDistributedCache cache, IOptionsMonitor<RedisOptions> options)
@@ -34,14 +32,19 @@ public class DungeonService : IDungeonService
     public async Task<string> StartDungeon(DungeonSession dungeonSession)
     {
         string key = Guid.NewGuid().ToString();
-        await cache.SetStringAsync(key, JsonSerializer.Serialize(dungeonSession), CacheOptions);
+        await cache.SetStringAsync(
+            Schema.DungeonKey_DungeonData(key),
+            JsonSerializer.Serialize(dungeonSession),
+            CacheOptions
+        );
         return key;
     }
 
     public async Task<DungeonSession> GetDungeon(string dungeonKey)
     {
         string json =
-            await cache.GetStringAsync(dungeonKey) ?? throw new DungeonException(dungeonKey);
+            await cache.GetStringAsync(Schema.DungeonKey_DungeonData(dungeonKey))
+            ?? throw new DungeonException(dungeonKey);
 
         return JsonSerializer.Deserialize<DungeonSession>(json)
             ?? throw new JsonException("Could not deserialize dungeon session.");
@@ -51,7 +54,7 @@ public class DungeonService : IDungeonService
     {
         DungeonSession session = await this.GetDungeon(dungeonKey);
 
-        await cache.RemoveAsync(dungeonKey);
+        await cache.RemoveAsync(Schema.DungeonKey_DungeonData(dungeonKey));
 
         return session;
     }

--- a/DragaliaAPI/Services/ISessionService.cs
+++ b/DragaliaAPI/Services/ISessionService.cs
@@ -21,18 +21,27 @@ public interface ISessionService
     Task<string> ActivateSession(string idToken);
 
     /// <summary>
-    /// Get a queryable for a player's savefile from an id token.
-    /// Warning: Will fail if ActivateSession() has been called.
+    /// Create a new session.
     /// </summary>
-    /// <param name="idToken"></param>
-    /// <returns></returns>
-    Task<string> GetDeviceAccountId_IdToken(string idToken);
+    /// <param name="idToken">The BaaS ID token/</param>
+    /// <param name="accountId">The BaaS subject.</param>
+    /// <param name="viewerId">The UserData ViewerID.</param>
+    /// <returns>The session ID.</returns>
+    Task<string> CreateSession(string idToken, string accountId, long viewerId);
 
     /// <summary>
-    /// Get a queryable for a player's savefile from a session id.
+    /// Get a session from an id.
     /// </summary>
     /// <param name="sessionId">The session id.</param>
-    /// <returns></returns>
-    Task<string> GetDeviceAccountId_SessionId(string sessionId);
-    Task<string> CreateSession(string accountId, string idToken);
+    /// <returns>The session object.</returns>
+    /// <exception cref="Exceptions.SessionException">A matching key was not found in the cache.</exception>
+    Task<Session> LoadSessionSessionId(string sessionId);
+
+    /// <summary>
+    /// Get a session from an id token.
+    /// </summary>
+    /// <param name="idToken">The ID token.</param>
+    /// <returns>The session object.</returns>
+    /// <exception cref="Exceptions.SessionException">A matching key was not found in the cache.</exception>
+    Task<Session> LoadSessionIdToken(string idToken);
 }

--- a/DragaliaAPI/Services/SessionService.cs
+++ b/DragaliaAPI/Services/SessionService.cs
@@ -71,7 +71,6 @@ public class SessionService : ISessionService
 
         if (!string.IsNullOrEmpty(existingSessionId))
         {
-            // TODO: Consider abstracting this into a RemoveSession method, in case it needs to be done elsewhere
             await cache.RemoveAsync(Schema.Session_SessionId(existingSessionId));
             await cache.RemoveAsync(Schema.SessionId_DeviceAccountId(deviceAccount.id));
         }

--- a/DragaliaAPI/Services/SessionService.cs
+++ b/DragaliaAPI/Services/SessionService.cs
@@ -1,6 +1,8 @@
 ﻿using DragaliaAPI.Models.Nintendo;
+using DragaliaAPI.Models.Options;
 using DragaliaAPI.Services.Exceptions;
 using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Options;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 
@@ -28,28 +30,29 @@ namespace DragaliaAPI.Services;
 public class SessionService : ISessionService
 {
     private readonly IDistributedCache cache;
-    private readonly DistributedCacheEntryOptions cacheOptions;
+    private readonly IOptionsMonitor<RedisOptions> options;
     private readonly ILogger<SessionService> logger;
+
+    private DistributedCacheEntryOptions CacheOptions =>
+        new()
+        {
+            SlidingExpiration = TimeSpan.FromMinutes(options.CurrentValue.SessionExpiryTimeMinutes)
+        };
 
     public SessionService(
         IDistributedCache cache,
-        IConfiguration configuration,
+        IOptionsMonitor<RedisOptions> options,
         ILogger<SessionService> logger
     )
     {
         this.cache = cache;
+        this.options = options;
         this.logger = logger;
-
-        int expiryTimeMinutes = configuration.GetValue<int>("SessionExpiryTimeMinutes");
-        cacheOptions = new() { SlidingExpiration = TimeSpan.FromMinutes(expiryTimeMinutes) };
     }
 
     private static class Schema
     {
-        public static string Session_IdToken(string idToken)
-        {
-            return $":session:id_token:{idToken}";
-        }
+        public static string Session_IdToken(string idToken) => $":session:id_token:{idToken}";
 
         public static string Session_SessionId(string sessionId) =>
             $":session:session_id:{sessionId}";
@@ -75,11 +78,12 @@ public class SessionService : ISessionService
 
         string sessionId = Guid.NewGuid().ToString();
 
-        Session session = new(sessionId, deviceAccount.id);
+        // Filler viewerid for session as this flow is deprecated
+        Session session = new(sessionId, idToken, deviceAccount.id, 47337);
         await cache.SetStringAsync(
             Schema.Session_IdToken(idToken),
             JsonSerializer.Serialize(session),
-            cacheOptions
+            CacheOptions
         );
 
         logger.LogInformation(
@@ -117,14 +121,14 @@ public class SessionService : ISessionService
         await cache.SetStringAsync(
             Schema.Session_SessionId(session.SessionId),
             JsonSerializer.Serialize(session),
-            cacheOptions
+            CacheOptions
         );
 
         // Register in existent sessions
         await cache.SetStringAsync(
             Schema.SessionId_DeviceAccountId(session.DeviceAccountId),
             session.SessionId,
-            cacheOptions
+            CacheOptions
         );
 
         this.logger.LogInformation(
@@ -136,7 +140,7 @@ public class SessionService : ISessionService
         return session.SessionId;
     }
 
-    public async Task<string> CreateSession(string accountId, string idToken)
+    public async Task<string> CreateSession(string idToken, string accountId, long viewerId)
     {
         // Check for existing session
         Session? existingSession = await this.TryLoadSession(Schema.Session_IdToken(idToken));
@@ -144,51 +148,33 @@ public class SessionService : ISessionService
             return existingSession.SessionId;
 
         string sessionId = Guid.NewGuid().ToString();
-        Session session = new(sessionId, accountId);
+        Session session = new(sessionId, idToken, accountId, viewerId);
 
         // Register in sessions by id token (for reauth)
         await cache.SetStringAsync(
             Schema.Session_IdToken(idToken),
             JsonSerializer.Serialize(session),
-            cacheOptions
+            CacheOptions
         );
 
-        // Register in sessions by session id (for account id retrieval)
+        // Register in sessions by session id (for all other endpoints)
         await cache.SetStringAsync(
             Schema.Session_SessionId(sessionId),
-            JsonSerializer.Serialize(session)
+            JsonSerializer.Serialize(session),
+            CacheOptions
         );
 
         return sessionId;
     }
 
-    public async Task<string> GetDeviceAccountId_SessionId(string sessionId)
-    {
-        Session session = await LoadSession(Schema.Session_SessionId(sessionId));
+    public async Task<Session> LoadSessionIdToken(string idToken) =>
+        await this.LoadSession(Schema.Session_IdToken(idToken));
 
-        return session.DeviceAccountId;
-    }
+    public async Task<Session> LoadSessionSessionId(string sessionId) =>
+        await this.LoadSession(Schema.Session_SessionId(sessionId));
 
-    public async Task<string> GetDeviceAccountId_IdToken(string idToken)
-    {
-        Session session = await LoadSession(Schema.Session_IdToken(idToken));
-
-        return session.DeviceAccountId;
-    }
-
-    private async Task<Session> LoadSession(string key)
-    {
-        string? sessionJson = await cache.GetStringAsync(key);
-        if (string.IsNullOrEmpty(sessionJson))
-        {
-            throw new SessionException(key);
-        }
-
-        return JsonSerializer.Deserialize<Session>(sessionJson)
-            ?? throw new JsonException(
-                $"Loaded session JSON {sessionJson} could not be deserialized."
-            );
-    }
+    private async Task<Session> LoadSession(string key) =>
+        await this.TryLoadSession(key) ?? throw new SessionException(key);
 
     private async Task<Session?> TryLoadSession(string key)
     {
@@ -199,6 +185,4 @@ public class SessionService : ISessionService
 
         return JsonSerializer.Deserialize<Session>(json);
     }
-
-    private record Session(string SessionId, string DeviceAccountId);
 }

--- a/DragaliaAPI/appsettings.json
+++ b/DragaliaAPI/appsettings.json
@@ -20,13 +20,13 @@
             {
                 "Name": "Console",
                 "Args": {
-                    "outputTemplate": "[{Timestamp:yyyy-MM-dd HH:mm:ss} {Level:u3} {SourceContext}][{RequestId}][{AccountId}] {Message:l}{NewLine}{Exception}"
+                    "outputTemplate": "[{Timestamp:yyyy-MM-dd HH:mm:ss} {Level:u3} {SourceContext}][{RequestId}][{AccountId}, {ViewerId}] {Message:l}{NewLine}{Exception}"
                 }
             },
             {
                 "Name": "File",
                 "Args": {
-                    "outputTemplate": "[{Timestamp:yyyy-MM-dd HH:mm:ss} {Level:u3} {SourceContext}][{RequestId}][{DeviceAccountId}] {Message:l}{NewLine}{Exception}",
+                    "outputTemplate": "[{Timestamp:yyyy-MM-dd HH:mm:ss} {Level:u3} {SourceContext}][{RequestId}][{DeviceAccountId}, {ViewerId}] {Message:l}{NewLine}{Exception}",
                     "path": "logs/dragaliaapi_.log",
                     "rollingInterval": "Day",
                     "rollOnFileSizeLimit": true,
@@ -53,6 +53,8 @@
         "Mode": "RAW"
     },
     "HashSalt": "dragalia",
-    "SessionExpiryTimeMinutes": 60,
-    "DungeonExpiryTimeMinutes": 60
+    "Redis": {
+        "SessionExpiryTimeMinutes": 60,
+        "DungeonExpiryTimeMinutes": 60
+    }
 }

--- a/DragaliaAPI/appsettings.json
+++ b/DragaliaAPI/appsettings.json
@@ -22,7 +22,7 @@
                 "Args": {
                     "formatter": {
                         "type": "Serilog.Templates.ExpressionTemplate, Serilog.Expressions",
-                        "template": "[{@t:yyyy-MM-dd HH:mm:ss} {@l:u3} {Substring(SourceContext, LastIndexOf(SourceContext, '.') + 1)}{Concat(' ', RequestId)}{Concat(' ', AccountId)}{Concat(' ', ViewerId)}] {@m}\n{@x}"
+                        "template": "[{@t:yyyy-MM-dd HH:mm:ss} {@l:u3} {Substring(SourceContext, LastIndexOf(SourceContext, '.') + 1)}{#each i in [RequestId, AccountId, ViewerId]}{Concat(' ', i)}{#end}] {@m}\n{@x}"
                     },
                 }
             },
@@ -31,7 +31,7 @@
                 "Args": {
                     "formatter": {
                         "type": "Serilog.Templates.ExpressionTemplate, Serilog.Expressions",
-                        "template": "[{@t:yyyy-MM-dd HH:mm:ss} {@l:u3} {Substring(SourceContext, LastIndexOf(SourceContext, '.') + 1)}{Concat(' ', RequestId)}{Concat(' ', AccountId)}{Concat(' ', ViewerId)}] {@m}\n{@x}"
+                        "template": "[{@t:yyyy-MM-dd HH:mm:ss} {@l:u3} {Substring(SourceContext, LastIndexOf(SourceContext, '.') + 1)}{#each i in [RequestId, AccountId, ViewerId]}{Concat(' ', i)}{#end}] {@m}\n{@x}"
                     },
                     "path": "logs/dragaliaapi_.log",
                     "rollingInterval": "Day",

--- a/DragaliaAPI/appsettings.json
+++ b/DragaliaAPI/appsettings.json
@@ -20,7 +20,7 @@
             {
                 "Name": "Console",
                 "Args": {
-                    "outputTemplate": "[{Timestamp:yyyy-MM-dd HH:mm:ss} {Level:u3} {SourceContext}][{RequestId}][{AccountId}, {ViewerId}] {Message:l}{NewLine}{Exception}"
+                    "outputTemplate": "[{Timestamp:yyyy-MM-dd HH:mm:ss} {Level:u3} {SourceContext}][{RequestId}][{AccountId}][{ViewerId}] {Message:l}{NewLine}{Exception}"
                 }
             },
             {

--- a/DragaliaAPI/appsettings.json
+++ b/DragaliaAPI/appsettings.json
@@ -20,13 +20,19 @@
             {
                 "Name": "Console",
                 "Args": {
-                    "outputTemplate": "[{Timestamp:yyyy-MM-dd HH:mm:ss} {Level:u3} {SourceContext}][{RequestId}][{AccountId}][{ViewerId}] {Message:l}{NewLine}{Exception}"
+                    "formatter": {
+                        "type": "Serilog.Templates.ExpressionTemplate, Serilog.Expressions",
+                        "template": "[{@t:yyyy-MM-dd HH:mm:ss} {@l:u3} {Substring(SourceContext, LastIndexOf(SourceContext, '.') + 1)}{Concat(' ', RequestId)}{Concat(' ', AccountId)}{Concat(' ', ViewerId)}] {@m}\n{@x}"
+                    },
                 }
             },
             {
                 "Name": "File",
                 "Args": {
-                    "outputTemplate": "[{Timestamp:yyyy-MM-dd HH:mm:ss} {Level:u3} {SourceContext}][{RequestId}][{DeviceAccountId}, {ViewerId}] {Message:l}{NewLine}{Exception}",
+                    "formatter": {
+                        "type": "Serilog.Templates.ExpressionTemplate, Serilog.Expressions",
+                        "template": "[{@t:yyyy-MM-dd HH:mm:ss} {@l:u3} {Substring(SourceContext, LastIndexOf(SourceContext, '.') + 1)}{Concat(' ', RequestId)}{Concat(' ', AccountId)}{Concat(' ', ViewerId)}] {@m}\n{@x}"
+                    },
                     "path": "logs/dragaliaapi_.log",
                     "rollingInterval": "Day",
                     "rollOnFileSizeLimit": true,


### PR DESCRIPTION
Should enable logs to be traced back to a user more easily (without a DB query) as they can provide their viewer ID due to it being publically visible.

Accomplished via adding it to the Session in Redis.

Also:

- Uses Serilog.Expressions for logging now that we have more properties to make it neater
- Adds modern SessionService tests
- Various Redis tweaks around config