### PR TITLE
Fix infinite session loop

### DIFF
--- a/DragaliaAPI/Controllers/Dragalia/RedoableSummonController.cs
+++ b/DragaliaAPI/Controllers/Dragalia/RedoableSummonController.cs
@@ -28,7 +28,7 @@ public class RedoableSummonController : DragaliaControllerBase
     private static class Schema
     {
         public static string SessionId_CachedSummonResult(string sessionId) =>
-            $":{sessionId}:cachedSummonResult";
+            $":cachedSummonResult:{sessionId}";
     }
 
     private static readonly OddsRate OddsRate =

--- a/DragaliaAPI/Services/SessionService.cs
+++ b/DragaliaAPI/Services/SessionService.cs
@@ -58,7 +58,7 @@ public class SessionService : ISessionService
             $":session:session_id:{sessionId}";
 
         public static string SessionId_DeviceAccountId(string deviceAccountId) =>
-            $":session_id:device_account_id:{deviceAccountId}";
+            $":session:device_account_id:{deviceAccountId}";
     }
 
     [Obsolete("Used for old pre-BaaS login flow")]


### PR DESCRIPTION
If your session expired, you get kicked out of SessionAuthenticationHandler with a SessionException to get a new token. Problem is that /tool/auth has to go through there too. So you would never be able to get into AuthService to make a new session. Fix that by allowing SessionErrors for AllowAnonymous controllers.