### PR TITLE
Add Seq logging

### DIFF
--- a/DragaliaAPI/DragaliaAPI.csproj
+++ b/DragaliaAPI/DragaliaAPI.csproj
@@ -35,8 +35,10 @@
 		<PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.25.1" />
 		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />
 		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="7.0.1" />
+		<PackageReference Include="Serilog.Exceptions" Version="8.4.0" />
 		<PackageReference Include="Serilog.Expressions" Version="3.4.2-dev-00119" />
 		<PackageReference Include="Serilog.Settings.Configuration" Version="3.5.0-dev-00367" />
+		<PackageReference Include="Serilog.Sinks.Seq" Version="5.2.2" />
 		<PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.25.1" />
 		<PackageReference Include="System.Text.Json" Version="7.0.1" />
 		<PackageReference Include="Serilog" Version="2.12.0" />

--- a/DragaliaAPI/appsettings.Development.json
+++ b/DragaliaAPI/appsettings.Development.json
@@ -17,13 +17,14 @@
                         "template": "[{@t:yyyy-MM-dd HH:mm:ss} {@l:u3} {Substring(SourceContext, LastIndexOf(SourceContext, '.') + 1)}{#each i in [RequestId, AccountId, ViewerId]}{Concat(' ', i)}{#end}] {@m}\n{@x}"
                     }
                 }
-            },
+            } /*,
             {
                 "Name": "Seq",
                 "Args": {
                     "serverUrl": "http://host.docker.internal:5341"
                 }
             }
+            */
         ]
     },
     "Login": {

--- a/DragaliaAPI/appsettings.Development.json
+++ b/DragaliaAPI/appsettings.Development.json
@@ -1,12 +1,30 @@
 {
     "Serilog": {
+        "Using": [ "Serilog.Exceptions", "Serilog.Sinks.Seq" ],
         "MinimumLevel": {
             "Default": "Information",
             "Override": {
                 "Microsoft.AspNetCore": "Warning",
                 "Microsoft.EntityFrameworkCore": "Information"
             }
-        }
+        },
+        "WriteTo": [
+            {
+                "Name": "Console",
+                "Args": {
+                    "formatter": {
+                        "type": "Serilog.Templates.ExpressionTemplate, Serilog.Expressions",
+                        "template": "[{@t:yyyy-MM-dd HH:mm:ss} {@l:u3} {Substring(SourceContext, LastIndexOf(SourceContext, '.') + 1)}{#each i in [RequestId, AccountId, ViewerId]}{Concat(' ', i)}{#end}] {@m}\n{@x}"
+                    }
+                }
+            },
+            {
+                "Name": "Seq",
+                "Args": {
+                    "serverUrl": "http://host.docker.internal:5341"
+                }
+            }
+        ]
     },
     "Login": {
         "UseBaasLogin": false

--- a/DragaliaAPI/appsettings.json
+++ b/DragaliaAPI/appsettings.json
@@ -1,6 +1,6 @@
 {
     "Serilog": {
-        "Using": [ "Serilog.Expressions" ],
+        "Using": [ "Serilog.Expressions", "Serilog.Exceptions" ],
         "Filter": [
             {
                 "Name": "ByExcluding",

--- a/DragaliaAPI/appsettings.json
+++ b/DragaliaAPI/appsettings.json
@@ -1,6 +1,5 @@
 {
     "Serilog": {
-        "Using": [ "Serilog.Expressions", "Serilog.Exceptions" ],
         "Filter": [
             {
                 "Name": "ByExcluding",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ name: DragaliaAPI
 
 volumes:
   pgdata:
-  #logs:
+  logs:
 
 services:
   dragaliaapi:
@@ -34,6 +34,7 @@ services:
       - 5432:5432
     volumes:
       - pgdata:/var/lib/postgresql/data
+      - logs:/app/logs
 
   redis:
     hostname: redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,8 +21,6 @@ services:
       - postgres
     env_file:
       - .env
-    volumes:
-      - logs:/app/logs
     
   postgres:
     hostname: postgres
@@ -43,3 +41,13 @@ services:
     ports:
       - 6379:6379
       - 8001:8001
+
+  seq:
+    image: datalust/seq:latest
+    ports:
+      - 5340:80
+      - 5341:5341
+    environment:
+      ACCEPT_EULA: "Y"
+    volumes:
+      - logs:/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ name: DragaliaAPI
 
 volumes:
   pgdata:
-  logs:
+  #logs:
 
 services:
   dragaliaapi:
@@ -42,12 +42,12 @@ services:
       - 6379:6379
       - 8001:8001
 
-  seq:
-    image: datalust/seq:latest
-    ports:
-      - 5340:80
-      - 5341:5341
-    environment:
-      ACCEPT_EULA: "Y"
-    volumes:
-      - logs:/data
+  #seq:
+  #  image: datalust/seq:latest
+  #  ports:
+  #    - 5340:80
+  #    - 5341:5341
+  #  environment:
+  #    ACCEPT_EULA: "Y"
+  #  volumes:
+  #    - logs:/data


### PR DESCRIPTION
Adds the packages for Seq logging. This is not in the helm chart unless enabled and requires admins to install the Seq chart themselves