### PR TITLE
Fix savefile import DbConcurrencyException

### DIFF
--- a/DragaliaAPI.Database.Test/DbTestFixture.cs
+++ b/DragaliaAPI.Database.Test/DbTestFixture.cs
@@ -3,6 +3,7 @@ using DragaliaAPI.Database.Entities;
 using DragaliaAPI.Database.Repositories;
 using DragaliaAPI.Services;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Logging;
 using Moq;
 
@@ -23,10 +24,13 @@ public class DbTestFixture : IDisposable
 
         this.ApiContext = new ApiContext(options);
         Mock<ILogger<SavefileService>> mockLogger = new(MockBehavior.Loose);
+        // Unused for creating saves
+        Mock<IDistributedCache> mockCache = new(MockBehavior.Loose);
 
         SavefileService savefileService =
             new(
                 this.ApiContext,
+                mockCache.Object,
                 new MapperConfiguration(
                     opts => opts.AddMaps(typeof(Program).Assembly)
                 ).CreateMapper(),

--- a/DragaliaAPI.Test/Integration/IntegrationTestFixture.cs
+++ b/DragaliaAPI.Test/Integration/IntegrationTestFixture.cs
@@ -8,6 +8,9 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Configuration;
 using DragaliaAPI.Services;
 using DragaliaAPI.Models.Generated;
+using System.Text.Json;
+using DragaliaAPI.Models;
+using DragaliaAPI.Shared.Json;
 
 namespace DragaliaAPI.Test.Integration;
 
@@ -19,31 +22,24 @@ public class IntegrationTestFixture : CustomWebApplicationFactory<Program>
         this.SeedCache();
 
         this.mockBaasRequestHelper.Setup(x => x.GetKeys()).ReturnsAsync(TestUtils.SecurityKeys);
-        this.mockBaasRequestHelper
-            .Setup(x => x.GetSavefile(It.IsAny<string>()))
-            .ReturnsAsync(
-                new LoadIndexData()
-                {
-                    user_data = new() { name = "Imported Save" },
-                    ability_crest_list = new List<AbilityCrestList>(),
-                    chara_list = new List<CharaList>(),
-                    dragon_list = new List<DragonList>(),
-                    talisman_list = new List<TalismanList>(),
-                    party_list = new List<PartyList>(),
-                    dragon_reliability_list = new List<DragonReliabilityList>(),
-                    weapon_body_list = new List<WeaponBodyList>(),
-                    quest_list = new List<QuestList>(),
-                    quest_story_list = new List<QuestStoryList>(),
-                    castle_story_list = new List<CastleStoryList>(),
-                    unit_story_list = new List<UnitStoryList>(),
-                    material_list = new List<MaterialList>(),
-                    build_list = new List<BuildList>(),
-                }
-            );
 
         this.mockLoginOptions
             .Setup(x => x.CurrentValue)
             .Returns(new Models.Options.LoginOptions() { UseBaasLogin = true });
+    }
+
+    public void SetupSaveImport()
+    {
+        this.mockBaasRequestHelper
+            .Setup(x => x.GetSavefile(It.IsAny<string>()))
+            .ReturnsAsync(
+                JsonSerializer
+                    .Deserialize<DragaliaResponse<LoadIndexData>>(
+                        File.ReadAllText(Path.Join("Data", "endgame_savefile.json")),
+                        ApiJsonOptions.Instance
+                    )!
+                    .data
+            );
     }
 
     /// <summary>

--- a/DragaliaAPI.Test/Unit/Services/AuthServiceTest.cs
+++ b/DragaliaAPI.Test/Unit/Services/AuthServiceTest.cs
@@ -215,17 +215,13 @@ public class AuthServiceTest
                         LastSaveImportTime = DateTimeOffset.UtcNow - TimeSpan.FromSeconds(1)
                     }
                 }.AsQueryable().BuildMock());
-        this.mockUserDataRepository
-            .Setup(x => x.UpdateSaveImportTime(AccountId))
-            .Returns(Task.CompletedTask);
-        this.mockUserDataRepository.Setup(x => x.SaveChangesAsync()).ReturnsAsync(1);
 
         this.mockSessionService
             .Setup(x => x.CreateSession(token, AccountId, 1))
             .ReturnsAsync("session id");
 
         this.mockSavefileService
-            .Setup(x => x.Import(AccountId, importSavefile))
+            .Setup(x => x.ThreadSafeImport(AccountId, importSavefile))
             .Returns(Task.CompletedTask);
 
         await this.authService.DoAuth(token);

--- a/DragaliaAPI/Controllers/Other/SavefileController.cs
+++ b/DragaliaAPI/Controllers/Other/SavefileController.cs
@@ -35,7 +35,7 @@ public class SavefileController : ControllerBase
         [FromBody] DragaliaResponse<LoadIndexData> loadIndexResponse
     )
     {
-        await this.savefileService.Import(
+        await this.savefileService.ThreadSafeImport(
             await this.LookupAccountId(viewerId),
             loadIndexResponse.data
         );

--- a/DragaliaAPI/Services/AuthService.cs
+++ b/DragaliaAPI/Services/AuthService.cs
@@ -107,7 +107,10 @@ public class AuthService : IAuthService
         long viewerId = await this.DoLogin(jwt.Subject);
         string sessionId = await this.sessionService.CreateSession(idToken, jwt.Subject, viewerId);
 
-        using IDisposable vIdLog = LogContext.PushProperty(CustomClaimType.ViewerId, viewerId);
+        using IDisposable vIdLog = LogContext.PushProperty(
+            CustomClaimType.ViewerId,
+            viewerId.ToString()
+        );
 
         this.logger.LogInformation(
             "Authenticated user with viewer ID {viewerid} and issued session ID {sid}",

--- a/DragaliaAPI/Services/AuthService.cs
+++ b/DragaliaAPI/Services/AuthService.cs
@@ -95,9 +95,7 @@ public class AuthService : IAuthService
             try
             {
                 LoadIndexData pendingSave = await this.baasRequestHelper.GetSavefile(idToken);
-                await this.savefileService.Import(jwt.Subject, pendingSave);
-                await this.userDataRepository.UpdateSaveImportTime(jwt.Subject);
-                await this.userDataRepository.SaveChangesAsync();
+                await this.savefileService.ThreadSafeImport(jwt.Subject, pendingSave);
             }
             catch (Exception e)
             {

--- a/DragaliaAPI/Services/ISavefileService.cs
+++ b/DragaliaAPI/Services/ISavefileService.cs
@@ -7,6 +7,7 @@ public interface ISavefileService
 {
     Task Create(string deviceAccountId);
     Task CreateBase(string deviceAccountId);
+    Task ThreadSafeImport(string deviceAccountId, LoadIndexData savefile);
     Task Import(string deviceAccountId, LoadIndexData savefile);
     IQueryable<DbPlayer> Load(string deviceAccountId);
     Task Reset(string deviceAccountId);

--- a/DragaliaAPI/Services/SavefileService.cs
+++ b/DragaliaAPI/Services/SavefileService.cs
@@ -58,11 +58,10 @@ public class SavefileService : ISavefileService
 
         if (!string.IsNullOrEmpty(await this.cache.GetStringAsync(key)))
         {
-            this.logger.LogInformation("Savefile import is locked, waiting...");
             while (!string.IsNullOrEmpty(await this.cache.GetStringAsync(key)))
             {
+                this.logger.LogInformation("Savefile import is locked, waiting...");
                 await Task.Delay(RecheckLockMs);
-                this.logger.LogInformation("Savefile import is still locked.");
             }
 
             this.logger.LogInformation("Savefile import lock released.");


### PR DESCRIPTION
If a save import took a long time, the client would re-call `/tool/auth` again before receiving a response.. This would trigger another save import while the existing one was running and lead to a DbConcurrencyException.

This PR:

- Adds a locking mechanism by setting a string derived from the account ID in Redis
- If a subsequent request is received, and a matching ID string is in Redis, no import is attempted and the Task is simply to wait until this key disappears
- Also converts `BaasRequestHelper` to use Redis to cache the jwks, thus making the main application truly stateless again.