### PR TITLE
Add basic property validation

### DIFF
--- a/DragaliaAPI.Database/Entities/DbParty.cs
+++ b/DragaliaAPI.Database/Entities/DbParty.cs
@@ -16,9 +16,10 @@ public class DbParty : IDbHasAccountId
     public required string DeviceAccountId { get; set; }
 
     [Required]
+    [Range(0, 54)]
     public int PartyNo { get; set; }
 
-    [MaxLength(64)]
+    [MaxLength(20)]
     public string PartyName { get; set; } = string.Empty;
 
     public ICollection<DbPartyUnit> Units { get; set; } = null!;

--- a/DragaliaAPI.Database/Entities/DbParty.cs
+++ b/DragaliaAPI.Database/Entities/DbParty.cs
@@ -16,7 +16,6 @@ public class DbParty : IDbHasAccountId
     public required string DeviceAccountId { get; set; }
 
     [Required]
-    [Range(0, 54)]
     public int PartyNo { get; set; }
 
     [MaxLength(20)]

--- a/DragaliaAPI.Database/Entities/DbPlayerUserData.cs
+++ b/DragaliaAPI.Database/Entities/DbPlayerUserData.cs
@@ -29,6 +29,7 @@ public class DbPlayerUserData : IDbHasAccountId
     /// <summary>
     /// The player's display name.
     /// </summary>
+    [MaxLength(10)]
     public string Name { get; set; } = "Euden";
 
     public int Level { get; set; } = 1;

--- a/DragaliaAPI.Database/Migrations/20230125000614_1-1-0_alpha_4.Designer.cs
+++ b/DragaliaAPI.Database/Migrations/20230125000614_1-1-0_alpha_4.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DragaliaAPI.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DragaliaAPI.Database.Migrations
 {
     [DbContext(typeof(ApiContext))]
-    partial class ApiContextModelSnapshot : ModelSnapshot
+    [Migration("20230125000614_1-1-0_alpha_4")]
+    partial class _110alpha4
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DragaliaAPI.Database/Migrations/20230125000614_1-1-0_alpha_4.cs
+++ b/DragaliaAPI.Database/Migrations/20230125000614_1-1-0_alpha_4.cs
@@ -1,0 +1,56 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DragaliaAPI.Database.Migrations
+{
+    /// <inheritdoc />
+    public partial class _110alpha4 : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "PlayerUserData",
+                type: "character varying(10)",
+                maxLength: 10,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "PartyName",
+                table: "PartyData",
+                type: "character varying(20)",
+                maxLength: 20,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(64)",
+                oldMaxLength: 64);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "PlayerUserData",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(10)",
+                oldMaxLength: 10);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "PartyName",
+                table: "PartyData",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(20)",
+                oldMaxLength: 20);
+        }
+    }
+}

--- a/DragaliaAPI/Models/Generated/Components.cs
+++ b/DragaliaAPI/Models/Generated/Components.cs
@@ -1,5 +1,6 @@
 #nullable disable
 
+using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 using DragaliaAPI.MessagePack;
 using DragaliaAPI.Shared.Definitions.Enums;
@@ -7171,6 +7172,8 @@ public class PartyInfo
 public class PartyList
 {
     public int party_no { get; set; }
+
+    [MaxLength(20)]
     public string party_name { get; set; }
     public IEnumerable<PartySettingList> party_setting_list { get; set; }
 
@@ -9039,6 +9042,8 @@ public class UserAmuletTradeList
 public class UserData
 {
     public ulong viewer_id { get; set; }
+
+    [MaxLength(10)]
     public string name { get; set; }
     public int level { get; set; }
     public int exp { get; set; }

--- a/DragaliaAPI/Models/Generated/LoadIndexData.cs
+++ b/DragaliaAPI/Models/Generated/LoadIndexData.cs
@@ -7,7 +7,7 @@ namespace DragaliaAPI.Models.Generated;
 public class LoadIndexData
 {
     [JsonRequired]
-    public UserData user_data { get; set; }
+    public UserData? user_data { get; set; }
     public PartyPowerData? party_power_data { get; set; }
 
     public IEnumerable<PartyList>? party_list { get; set; }
@@ -46,7 +46,9 @@ public class LoadIndexData
     public IEnumerable<QuestWallList>? quest_wall_list { get; set; }
     public IEnumerable<QuestCarryList>? quest_carry_list { get; set; }
     public IEnumerable<QuestEntryConditionList>? quest_entry_condition_list { get; set; }
-    public FortBonusList fort_bonus_list { get; set; }
+
+    [JsonIgnore]
+    public FortBonusList? fort_bonus_list { get; set; }
 
     public IEnumerable<BuildList>? build_list { get; set; } = new List<BuildList>();
     public IEnumerable<CraftList>? craft_list { get; set; }
@@ -94,7 +96,11 @@ public class LoadIndexData
     public DateTimeOffset server_time { get; set; }
     public int quest_bonus_stack_base_time { get; set; }
     public IEnumerable<AtgenQuestBonus>? quest_bonus { get; set; }
+
+    [JsonIgnore]
     public AtgenMultiServer? multi_server { get; set; }
+
+    [JsonIgnore]
     public AtgenWalkerData? walker_data { get; set; }
 
     [JsonConstructor]

--- a/DragaliaAPI/Models/Generated/Requests.cs
+++ b/DragaliaAPI/Models/Generated/Requests.cs
@@ -1,5 +1,6 @@
 #nullable disable
 
+using System.ComponentModel.DataAnnotations;
 using DragaliaAPI.Shared.Definitions.Enums;
 using MessagePack;
 
@@ -3111,6 +3112,8 @@ public class PartySetPartySettingRequest
 {
     public int party_no { get; set; }
     public IEnumerable<PartySettingList> request_party_setting_list { get; set; }
+
+    [MaxLength(20)]
     public string party_name { get; set; }
     public int is_entrust { get; set; }
     public int entrust_element { get; set; }
@@ -3137,6 +3140,8 @@ public class PartySetPartySettingRequest
 public class PartyUpdatePartyNameRequest
 {
     public int party_no { get; set; }
+
+    [MaxLength(20)]
     public string party_name { get; set; }
 
     public PartyUpdatePartyNameRequest(int party_no, string party_name)
@@ -4049,6 +4054,7 @@ public class TutorialUpdateStepRequest
 [MessagePackObject(true)]
 public class UpdateNamechangeRequest
 {
+    [MaxLength(10)]
     public string name { get; set; }
 
     public UpdateNamechangeRequest(string name)

--- a/DragaliaAPI/Services/SavefileService.cs
+++ b/DragaliaAPI/Services/SavefileService.cs
@@ -119,6 +119,9 @@ public class SavefileService : ISavefileService
 
         this.logger.LogDebug("Added new Player entry");
 
+        // This has JsonRequired so this should never be triggered
+        ArgumentNullException.ThrowIfNull(savefile.user_data);
+
         apiContext.PlayerUserData.Add(
             this.mapper.Map<DbPlayerUserData>(
                 savefile.user_data,


### PR DESCRIPTION
This is by no means exhaustive but the focus for now is limiting the length of strings, particularly those which may end up in the database -- Postgres is ridiculously forgiving with its TEXT type.

One other area worth looking at it party numbers and unit positions, these will put the DB In a funny state but are unlikely to cause any issues for users beyond the one with the invalid data.