### PR TITLE
Fix InventoryRepository issue

### DIFF
--- a/DragaliaAPI.Database.Test/Repositories/InventoryRepositoryTest.cs
+++ b/DragaliaAPI.Database.Test/Repositories/InventoryRepositoryTest.cs
@@ -1,0 +1,193 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DragaliaAPI.Database.Entities;
+using DragaliaAPI.Database.Repositories;
+using DragaliaAPI.Shared.Definitions.Enums;
+using FluentAssertions.Extensions;
+using Microsoft.EntityFrameworkCore;
+using static DragaliaAPI.Database.Test.DbTestFixture;
+
+namespace DragaliaAPI.Database.Test.Repositories;
+
+public class InventoryRepositoryTest : IClassFixture<DbTestFixture>
+{
+    private readonly DbTestFixture fixture;
+    private readonly IInventoryRepository inventoryRepository;
+
+    public InventoryRepositoryTest(DbTestFixture fixture)
+    {
+        this.fixture = fixture;
+        this.inventoryRepository = new InventoryRepository(this.fixture.ApiContext);
+
+        AssertionOptions.AssertEquivalencyUsing(x => x.Excluding(x => x.Name.StartsWith("Owner")));
+    }
+
+    [Fact]
+    public async Task AddMaterialQuantity_NoEntry_AddsQuantity()
+    {
+        await this.inventoryRepository.AddMaterialQuantity(
+            DeviceAccountId,
+            Materials.FirestormPrism,
+            10
+        );
+
+        (
+            await this.fixture.ApiContext.PlayerMaterials.FindAsync(
+                DeviceAccountId,
+                Materials.FirestormPrism
+            )
+        )!.Quantity
+            .Should()
+            .Be(10);
+    }
+
+    [Fact]
+    public async Task AddMaterialQuantity_ExistingEntry_AddsQuantity()
+    {
+        await this.fixture.ApiContext.AddAsync(
+            new DbPlayerMaterial()
+            {
+                DeviceAccountId = DeviceAccountId,
+                MaterialId = Materials.FirestormPrism,
+                Quantity = 0
+            }
+        );
+
+        await this.fixture.ApiContext.SaveChangesAsync();
+
+        await this.inventoryRepository.AddMaterialQuantity(
+            DeviceAccountId,
+            Materials.FirestormPrism,
+            10
+        );
+
+        (
+            await this.fixture.ApiContext.PlayerMaterials.FindAsync(
+                DeviceAccountId,
+                Materials.FirestormPrism
+            )
+        )!.Quantity
+            .Should()
+            .Be(10);
+    }
+
+    [Fact]
+    public async Task AddMaterialQuantityRange_AddsQuantities()
+    {
+        await this.inventoryRepository.AddMaterialQuantity(
+            DeviceAccountId,
+            new List<Materials>() { Materials.SunlightOre, Materials.SunlightStone },
+            5
+        );
+
+        (
+            await this.fixture.ApiContext.PlayerMaterials.FindAsync(
+                DeviceAccountId,
+                Materials.SunlightOre
+            )
+        )!.Quantity
+            .Should()
+            .Be(5);
+
+        (
+            await this.fixture.ApiContext.PlayerMaterials.FindAsync(
+                DeviceAccountId,
+                Materials.SunlightStone
+            )
+        )!.Quantity
+            .Should()
+            .Be(5);
+    }
+
+    [Fact]
+    public async Task GetMaterial_FiltersByAccountId()
+    {
+        await this.fixture.ApiContext.PlayerMaterials.AddRangeAsync(
+            new List<DbPlayerMaterial>()
+            {
+                new()
+                {
+                    DeviceAccountId = "other id",
+                    MaterialId = Materials.AbaddonOrb,
+                    Quantity = 5
+                },
+                new()
+                {
+                    DeviceAccountId = DeviceAccountId,
+                    MaterialId = Materials.AbaddonOrb,
+                    Quantity = 50,
+                }
+            }
+        );
+
+        await this.fixture.ApiContext.SaveChangesAsync();
+
+        (await this.inventoryRepository.GetMaterial(DeviceAccountId, Materials.AbaddonOrb))
+            .Should()
+            .NotBeNull()
+            .And.BeEquivalentTo(
+                new DbPlayerMaterial()
+                {
+                    DeviceAccountId = DeviceAccountId,
+                    MaterialId = Materials.AbaddonOrb,
+                    Quantity = 50
+                },
+                opts => opts.Excluding(x => x.Owner)
+            );
+    }
+
+    [Fact]
+    public async Task GetMaterials_FiltersByAccountId()
+    {
+        await this.fixture.ApiContext.PlayerMaterials.AddRangeAsync(
+            new List<DbPlayerMaterial>()
+            {
+                new()
+                {
+                    DeviceAccountId = "other id",
+                    MaterialId = Materials.AbaddonOrb,
+                    Quantity = 5
+                },
+                new()
+                {
+                    DeviceAccountId = DeviceAccountId,
+                    MaterialId = Materials.TsunamiOrb,
+                    Quantity = 50,
+                },
+                new()
+                {
+                    DeviceAccountId = DeviceAccountId,
+                    MaterialId = Materials.InfernoOrb,
+                    Quantity = 50,
+                }
+            }
+        );
+
+        await this.fixture.ApiContext.SaveChangesAsync();
+
+        (await this.inventoryRepository.GetMaterials(DeviceAccountId).ToListAsync())
+            .Should()
+            .ContainEquivalentOf( // Savefile creation adds materials
+                new DbPlayerMaterial()
+                {
+                    DeviceAccountId = DeviceAccountId,
+                    MaterialId = Materials.TsunamiOrb,
+                    Quantity = 50
+                },
+                opts => opts.Excluding(x => x.Owner)
+            )
+            .And.ContainEquivalentOf(
+                new DbPlayerMaterial()
+                {
+                    DeviceAccountId = DeviceAccountId,
+                    MaterialId = Materials.InfernoOrb,
+                    Quantity = 50
+                },
+                opts => opts.Excluding(x => x.Owner)
+            )
+            .And.AllSatisfy(x => x.DeviceAccountId.Should().Be(DeviceAccountId));
+    }
+}

--- a/DragaliaAPI.Database.Test/Repositories/InventoryRepositoryTest.cs
+++ b/DragaliaAPI.Database.Test/Repositories/InventoryRepositoryTest.cs
@@ -30,14 +30,14 @@ public class InventoryRepositoryTest : IClassFixture<DbTestFixture>
     {
         await this.inventoryRepository.AddMaterialQuantity(
             DeviceAccountId,
-            Materials.FirestormPrism,
+            Materials.WaterwyrmsGreatsphere,
             10
         );
 
         (
             await this.fixture.ApiContext.PlayerMaterials.FindAsync(
                 DeviceAccountId,
-                Materials.FirestormPrism
+                Materials.WaterwyrmsGreatsphere
             )
         )!.Quantity
             .Should()
@@ -147,7 +147,7 @@ public class InventoryRepositoryTest : IClassFixture<DbTestFixture>
             {
                 new()
                 {
-                    DeviceAccountId = "other id",
+                    DeviceAccountId = "other id 2",
                     MaterialId = Materials.AbaddonOrb,
                     Quantity = 5
                 },

--- a/DragaliaAPI.Database/ApiContext.cs
+++ b/DragaliaAPI.Database/ApiContext.cs
@@ -99,7 +99,7 @@ public class ApiContext : DbContext
 
     public DbSet<DbPlayerCurrency> PlayerWallet { get; set; }
 
-    public DbSet<DbPlayerMaterial> PlayerStorage { get; set; }
+    public DbSet<DbPlayerMaterial> PlayerMaterials { get; set; }
 
     public DbSet<DbSetUnit> PlayerSetUnits { get; set; }
 

--- a/DragaliaAPI.Database/Repositories/InventoryRepository.cs
+++ b/DragaliaAPI.Database/Repositories/InventoryRepository.cs
@@ -44,7 +44,7 @@ public class InventoryRepository : BaseRepository, IInventoryRepository
 
     public DbPlayerMaterial AddMaterial(string deviceAccountId, Materials type)
     {
-        return apiContext.PlayerStorage
+        return apiContext.PlayerMaterials
             .Add(
                 new DbPlayerMaterial()
                 {
@@ -59,7 +59,7 @@ public class InventoryRepository : BaseRepository, IInventoryRepository
     public async Task AddMaterialQuantity(string deviceAccountId, Materials item, int quantity)
     {
         DbPlayerMaterial material =
-            await this.apiContext.PlayerStorage.FindAsync(deviceAccountId, item)
+            await this.apiContext.PlayerMaterials.FindAsync(deviceAccountId, item)
             ?? (
                 await this.apiContext.AddAsync(
                     new DbPlayerMaterial()
@@ -97,14 +97,12 @@ public class InventoryRepository : BaseRepository, IInventoryRepository
 
     public async Task<DbPlayerMaterial?> GetMaterial(string deviceAccountId, Materials materialId)
     {
-        return await this.apiContext.PlayerStorage.FirstOrDefaultAsync(
-            entry => entry.MaterialId == materialId
-        );
+        return await this.apiContext.PlayerMaterials.FindAsync(deviceAccountId, materialId);
     }
 
     public IQueryable<DbPlayerMaterial> GetMaterials(string deviceAccountId)
     {
-        return this.apiContext.PlayerStorage.Where(
+        return this.apiContext.PlayerMaterials.Where(
             storage => storage.DeviceAccountId == deviceAccountId
         );
     }

--- a/DragaliaAPI.Test/Integration/Dragalia/PartyTest.cs
+++ b/DragaliaAPI.Test/Integration/Dragalia/PartyTest.cs
@@ -1,6 +1,7 @@
 ﻿using System.Net;
 using DragaliaAPI.Database;
 using DragaliaAPI.Database.Entities;
+using DragaliaAPI.Models;
 using DragaliaAPI.Models.Generated;
 using DragaliaAPI.Shared.Definitions.Enums;
 using MessagePack;
@@ -115,7 +116,7 @@ public class PartyTest : IClassFixture<IntegrationTestFixture>
     }
 
     [Fact]
-    public async Task SetPartySetting_InvalidRequest_NotOwnedCharacter_ReturnsBadRequest()
+    public async Task SetPartySetting_InvalidRequest_NotOwnedCharacter_ReturnsResultCode()
     {
         PartySetPartySettingRequest request =
             new(
@@ -129,15 +130,24 @@ public class PartyTest : IClassFixture<IntegrationTestFixture>
                 0
             );
 
-        HttpContent content = TestUtils.CreateMsgpackContent(request);
-
-        HttpResponseMessage response = await client.PostAsync("/party/set_party_setting", content);
-
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        (
+            await this.client.PostMsgpack<ResultCodeData>(
+                "/party/set_party_setting",
+                request,
+                ensureSuccessHeader: false
+            )
+        )
+            .Should()
+            .BeEquivalentTo(
+                new DragaliaResponse<ResultCodeData>(
+                    new DataHeaders(ResultCode.PartySwitchSettingCharaShort),
+                    new ResultCodeData(ResultCode.PartySwitchSettingCharaShort)
+                )
+            );
     }
 
     [Fact]
-    public async Task SetPartySetting_InvalidRequest_NotOwnedDragonKeyId_ReturnsBadRequest()
+    public async Task SetPartySetting_InvalidRequest_NotOwnedDragonKeyId_ReturnsResultCode()
     {
         PartySetPartySettingRequest request =
             new(
@@ -151,11 +161,20 @@ public class PartyTest : IClassFixture<IntegrationTestFixture>
                 0
             );
 
-        HttpContent content = TestUtils.CreateMsgpackContent(request);
-
-        HttpResponseMessage response = await client.PostAsync("/party/set_party_setting", content);
-
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        (
+            await this.client.PostMsgpack<ResultCodeData>(
+                "/party/set_party_setting",
+                request,
+                ensureSuccessHeader: false
+            )
+        )
+            .Should()
+            .BeEquivalentTo(
+                new DragaliaResponse<ResultCodeData>(
+                    new DataHeaders(ResultCode.PartySwitchSettingCharaShort),
+                    new ResultCodeData(ResultCode.PartySwitchSettingCharaShort)
+                )
+            );
     }
 
     [Fact]

--- a/DragaliaAPI.Test/Integration/IntegrationTestFixture.cs
+++ b/DragaliaAPI.Test/Integration/IntegrationTestFixture.cs
@@ -69,7 +69,7 @@ public class IntegrationTestFixture : CustomWebApplicationFactory<Program>
     {
         using IServiceScope scope = this.Services.CreateScope();
         ApiContext inventoryRepo = scope.ServiceProvider.GetRequiredService<ApiContext>();
-        inventoryRepo.PlayerStorage.AddRange(
+        inventoryRepo.PlayerMaterials.AddRange(
             Enum.GetValues(typeof(Materials))
                 .OfType<Materials>()
                 .Select(

--- a/DragaliaAPI.Test/Integration/Other/SavefileImportTest.cs
+++ b/DragaliaAPI.Test/Integration/Other/SavefileImportTest.cs
@@ -103,6 +103,7 @@ public class SavefileImportTest : IClassFixture<IntegrationTestFixture>
                             x.Path.StartsWith("ability_crest_list")
                             && (x.Name == "ability_1_level" || x.Name == "ability_2_level")
                     );
+                    opts.Excluding(x => x.user_data.level);
 
                     // Free wyrmite
                     opts.Excluding(x => x.user_data.crystal);

--- a/DragaliaAPI/Controllers/Dragalia/DeployController.cs
+++ b/DragaliaAPI/Controllers/Dragalia/DeployController.cs
@@ -1,11 +1,11 @@
 ﻿using DragaliaAPI.Models.Generated;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace DragaliaAPI.Controllers.Dragalia;
 
 [Route("deploy")]
-[Consumes("application/octet-stream")]
-[Produces("application/octet-stream")]
+[AllowAnonymous]
 [ApiController]
 public class DeployController : DragaliaControllerBase
 {

--- a/DragaliaAPI/Controllers/Dragalia/PartyController.cs
+++ b/DragaliaAPI/Controllers/Dragalia/PartyController.cs
@@ -4,6 +4,7 @@ using DragaliaAPI.Database.Repositories;
 using DragaliaAPI.Models;
 using DragaliaAPI.Models.Generated;
 using DragaliaAPI.Services;
+using DragaliaAPI.Services.Exceptions;
 using DragaliaAPI.Shared.Definitions.Enums;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -69,7 +70,7 @@ public class PartyController : DragaliaControllerBase
                 )
             )
             {
-                return this.BadRequest();
+                throw new DragaliaException(ResultCode.PartySwitchSettingCharaShort);
             }
         }
 
@@ -124,6 +125,7 @@ public class PartyController : DragaliaControllerBase
         if (id == Charas.Empty)
             return true;
 
+        // TODO: can make this single query instead of 8 (this method is called in a loop)
         IEnumerable<Charas> ownedCharaIds = await this.unitRepository
             .GetAllCharaData(deviceAccountId)
             .Select(x => x.CharaId)

--- a/DragaliaAPI/Controllers/Dragalia/SummonController.cs
+++ b/DragaliaAPI/Controllers/Dragalia/SummonController.cs
@@ -488,7 +488,20 @@ public class SummonController : DragaliaControllerBase
                 new List<int>() { sageEffect, circleEffect },
                 reversalIndex,
                 updateDataList,
-                new EntityResult(),
+                new EntityResult()
+                {
+                    new_get_entity_list = charaRewardList
+                        .Concat(dragonRewardList)
+                        .Where(x => x.is_new)
+                        .Select(
+                            x =>
+                                new AtgenDuplicateEntityList()
+                                {
+                                    entity_id = x.id,
+                                    entity_type = x.entity_type
+                                }
+                        )
+                },
                 new List<SummonTicketList>(),
                 playerBannerData.SummonPoints,
                 new List<UserSummonList>()

--- a/DragaliaAPI/Controllers/Dragalia/VersionController.cs
+++ b/DragaliaAPI/Controllers/Dragalia/VersionController.cs
@@ -1,9 +1,11 @@
 ﻿using DragaliaAPI.Models.Generated;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace DragaliaAPI.Controllers.Dragalia;
 
 [Route("version")]
+[AllowAnonymous]
 public class VersionController : DragaliaControllerBase
 {
     private const string AndroidResourceVersion = "y2XM6giU6zz56wCm";

--- a/DragaliaAPI/Models/AutoMapper/UserDataMapProfile.cs
+++ b/DragaliaAPI/Models/AutoMapper/UserDataMapProfile.cs
@@ -15,8 +15,9 @@ public class UserDataMapProfile : Profile
             .ForMember(x => x.is_optin, opts => opts.MapFrom(x => 0))
             .ForMember(x => x.prologue_end_time, opts => opts.MapFrom(x => 0))
             // TODO: add proper stamina/getherwing increases with level
-            .ForMember(x => x.stamina_single, opts => opts.MapFrom(x => 99))
-            .ForMember(x => x.stamina_multi, opts => opts.MapFrom(x => 99));
+            .ForMember(x => x.stamina_single, opts => opts.MapFrom(x => 999))
+            .ForMember(x => x.stamina_multi, opts => opts.MapFrom(x => 99))
+            .ForMember(x => x.level, opts => opts.MapFrom(x => 200));
 
         this.SourceMemberNamingConvention = DatabaseNamingConvention.Instance;
         this.DestinationMemberNamingConvention = LowerUnderscoreNamingConvention.Instance;

--- a/DragaliaAPI/Models/Generated/LoadIndexData.cs
+++ b/DragaliaAPI/Models/Generated/LoadIndexData.cs
@@ -10,6 +10,7 @@ public class LoadIndexData
     public UserData? user_data { get; set; }
     public PartyPowerData? party_power_data { get; set; }
 
+    [JsonRequired]
     public IEnumerable<PartyList>? party_list { get; set; }
 
     public IEnumerable<CharaList>? chara_list { get; set; }

--- a/DragaliaAPI/Services/AuthService.cs
+++ b/DragaliaAPI/Services/AuthService.cs
@@ -113,10 +113,7 @@ public class AuthService : IAuthService
         long viewerId = await this.DoLogin(jwt.Subject);
         string sessionId = await this.sessionService.CreateSession(idToken, jwt.Subject, viewerId);
 
-        using IDisposable vIdLog = LogContext.PushProperty(
-            CustomClaimType.ViewerId,
-            viewerId.ToString()
-        );
+        using IDisposable vIdLog = LogContext.PushProperty(CustomClaimType.ViewerId, viewerId);
 
         this.logger.LogInformation(
             "Authenticated user with viewer ID {id} and issued session ID {sid}",
@@ -141,7 +138,7 @@ public class AuthService : IAuthService
 
         if (!validationResult.IsValid)
         {
-            string idTokenTrace = idToken[..^5];
+            string idTokenTrace = idToken[^5..];
             string? accountId = (validationResult.SecurityToken as JwtSecurityToken)?.Subject;
 
             LogContext.PushProperty(CustomClaimType.AccountId, accountId);

--- a/DragaliaAPI/Services/SavefileService.cs
+++ b/DragaliaAPI/Services/SavefileService.cs
@@ -258,7 +258,7 @@ public class SavefileService : ISavefileService
 
         this.logger.LogDebug("Added stories");
 
-        this.apiContext.PlayerStorage.AddRange(
+        this.apiContext.PlayerMaterials.AddRange(
             MapWithDeviceAccount<DbPlayerMaterial>(savefile.material_list, deviceAccountId)
         );
 
@@ -328,8 +328,8 @@ public class SavefileService : ISavefileService
         this.apiContext.PlayerWeapons.RemoveRange(
             this.apiContext.PlayerWeapons.Where(x => x.DeviceAccountId == deviceAccountId)
         );
-        this.apiContext.PlayerStorage.RemoveRange(
-            this.apiContext.PlayerStorage.Where(x => x.DeviceAccountId == deviceAccountId)
+        this.apiContext.PlayerMaterials.RemoveRange(
+            this.apiContext.PlayerMaterials.Where(x => x.DeviceAccountId == deviceAccountId)
         );
         this.apiContext.PlayerFortBuilds.RemoveRange(
             this.apiContext.PlayerFortBuilds.Where(x => x.DeviceAccountId == deviceAccountId)
@@ -626,7 +626,7 @@ public class SavefileService : ISavefileService
 
     private async Task AddDefaultMaterials(string deviceAccountId, int defaultQuantity = 10000)
     {
-        await this.apiContext.PlayerStorage.AddRangeAsync(
+        await this.apiContext.PlayerMaterials.AddRangeAsync(
             DefaultSavefileData.UpgradeMaterials.Select(
                 x =>
                     new DbPlayerMaterial()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     environment:
       - ASPNETCORE_URLS=https://+:443;http://+:80
     ports:
-      - "80:80"
+      - "5000:80"
       - "5001:443"
     links:
       - postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     environment:
       - ASPNETCORE_URLS=https://+:443;http://+:80
     ports:
-      - "5000:80"
+      - "80:80"
       - "5001:443"
     links:
       - postgres


### PR DESCRIPTION
- Fixes GetMaterial not filtering by account id -- closes #104 
   - Adds tests for InventoryRepository
- Adds new_get_entity_list to /summon/request response.  Further investigation required on #90 to see if this fixes
- For better visibility of #112 , returns a proper result code response from /party/set_party_setting rather than HTTP 400
- Maps everyone's level from 200 so that stamina is maxed out, enabling players w/o a save import to play endgame quests
- Makes party_list a required property in the save as importing a save without this leads to a softlock