### PR TITLE
Disable token refresh 400 response

### DIFF
--- a/DragaliaAPI.Test/Integration/Dragalia/ToolTest.cs
+++ b/DragaliaAPI.Test/Integration/Dragalia/ToolTest.cs
@@ -60,7 +60,7 @@ public class ToolTest : IClassFixture<IntegrationTestFixture>
         response.viewer_id.Should().Be(2);
     }
 
-    [Fact]
+    /*[Fact]
     public async Task Signup_ExpiredIdToken_ReturnsRefreshRequest()
     {
         HttpResponseMessage response = await client.PostMsgpackBasic(
@@ -82,7 +82,7 @@ public class ToolTest : IClassFixture<IntegrationTestFixture>
             .GetValues("Is-Required-Refresh-Id-Token")
             .Should()
             .BeEquivalentTo(new List<string>() { "true" });
-    }
+    }*/
 
     [Fact]
     public async Task Signup_InvalidIdToken_ReturnsIdTokenError()
@@ -150,7 +150,7 @@ public class ToolTest : IClassFixture<IntegrationTestFixture>
         response.session_id.Should().Be(response2.session_id);
     }
 
-    [Fact]
+    /*[Fact]
     public async Task Auth_ExpiredIdToken_ReturnsRefreshRequest()
     {
         HttpResponseMessage response = await client.PostMsgpackBasic(
@@ -172,7 +172,7 @@ public class ToolTest : IClassFixture<IntegrationTestFixture>
             .GetValues("Is-Required-Refresh-Id-Token")
             .Should()
             .BeEquivalentTo(new List<string>() { "true" });
-    }
+    }*/
 
     [Fact]
     public async Task Auth_InvalidIdToken_ReturnsIdTokenError()

--- a/DragaliaAPI/Middleware/ExceptionHandlerMiddleware.cs
+++ b/DragaliaAPI/Middleware/ExceptionHandlerMiddleware.cs
@@ -55,7 +55,7 @@ public class ExceptionHandlerMiddleware
 
                 return;
             }
-            else if (ex is SecurityTokenExpiredException)
+            /*else if (ex is SecurityTokenExpiredException)
             {
                 // Will send back to BaaS to login
                 this.logger.LogInformation(
@@ -65,9 +65,9 @@ public class ExceptionHandlerMiddleware
                 context.Response.Headers.Add(RefreshIdToken, True);
 
                 return;
-            }
+            }*/
 
-            this.logger.LogError("Encountered unhandled exception: {exception}", ex);
+            this.logger.LogError(ex, "Encountered unhandled exception");
 
             context.Response.ContentType = CustomMessagePackOutputFormatter.ContentType;
             context.Response.StatusCode = 200;
@@ -75,6 +75,8 @@ public class ExceptionHandlerMiddleware
             ResultCode code = ex is DragaliaException dragaliaException
                 ? dragaliaException.Code
                 : ServerErrorCode;
+
+            code = ex is SecurityTokenExpiredException ? ResultCode.IdTokenError : code;
 
             this.logger.LogError("Returning result_code {code}", code);
 


### PR DESCRIPTION
Patch fix for #115 pending actual investigation. Makes SecurityTokenExpiredException boot to title screen instead of trying to refresh silently 'the cool way'.