### PR TITLE
Add 404 handling middleware

### DIFF
--- a/DragaliaAPI/Middleware/NotFoundHandlerMiddleware.cs
+++ b/DragaliaAPI/Middleware/NotFoundHandlerMiddleware.cs
@@ -1,0 +1,47 @@
+﻿using System.Net;
+using DragaliaAPI.MessagePack;
+using DragaliaAPI.Models;
+using MessagePack;
+
+namespace DragaliaAPI.Middleware;
+
+public class NotFoundHandlerMiddleware
+{
+    private readonly ILogger<NotFoundHandlerMiddleware> logger;
+    private readonly RequestDelegate next;
+
+    private const string AndroidPathBase = "/2.19.0_20220714193707";
+    private const string IosPathBase = "/2.19.0_20220719103923";
+
+    private const ResultCode NotFoundCode = ResultCode.CommonTimeout; // Shows error 'Failed to connect to the server'
+
+    public NotFoundHandlerMiddleware(RequestDelegate next, ILoggerFactory logger)
+    {
+        this.next = next;
+        this.logger = logger.CreateLogger<NotFoundHandlerMiddleware>();
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        await next(context);
+
+        if (
+            context.Response.StatusCode == (int)HttpStatusCode.NotFound
+            && (
+                context.Request.PathBase == IosPathBase
+                || context.Request.PathBase == AndroidPathBase
+            )
+        )
+        {
+            this.logger.LogInformation("HTTP 404 on {RequestPath}", context.Request.Path);
+            context.Response.StatusCode = (int)HttpStatusCode.OK;
+
+            DragaliaResponse<ResultCodeData> gameResponse =
+                new(new DataHeaders(NotFoundCode), new(NotFoundCode));
+
+            await context.Response.Body.WriteAsync(
+                MessagePackSerializer.Serialize(gameResponse, CustomResolver.Options)
+            );
+        }
+    }
+}

--- a/DragaliaAPI/Program.cs
+++ b/DragaliaAPI/Program.cs
@@ -133,6 +133,7 @@ app.UsePathBase("/2.19.0_20220714193707");
 // Latest iOS app version
 app.UsePathBase("/2.19.0_20220719103923");
 app.UseMiddleware<ExceptionHandlerMiddleware>();
+app.UseMiddleware<NotFoundHandlerMiddleware>();
 
 app.UseRouting();
 app.UseAuthentication();


### PR DESCRIPTION
Adds middleware to handle 404 errors so that these do not cause a kick to the title screen. Replaces it with a result_code response that instances a pop-up which can simply be closed.