### PR TITLE
Save import fixes

### DIFF
--- a/DragaliaAPI.Test/Integration/Other/ExceptionHandlerMiddlewareTest.cs
+++ b/DragaliaAPI.Test/Integration/Other/ExceptionHandlerMiddlewareTest.cs
@@ -15,19 +15,6 @@ public class ExceptionHandlerMiddlewareTest : IntegrationTestBase
         client = fixture.CreateClient();
     }
 
-    [Theory]
-    [InlineData("taskcancelled")]
-    [InlineData("messagepackserialization/taskcancelled")]
-    [InlineData("messagepackserialization/operationcancelled")]
-    public async Task TransientException_Returns503(string route)
-    {
-        client.DefaultRequestHeaders.Add("SID", "session_id");
-
-        HttpResponseMessage response = await client.GetAsync($"{Controller}/{route}");
-
-        response.StatusCode.Should().Be(System.Net.HttpStatusCode.ServiceUnavailable);
-    }
-
     [Fact]
     public async Task DragaliaException_ReturnsSerializedResponse()
     {


### PR DESCRIPTION
Noticed a PK conflict in Players when a new player joins using a save that's invalid and goes into the creating savefile code. Not sure of the cause, but attempt to address it by:

- Explicitly rolling back the transaction on save import errors
- Deleting savefile on creating a new one and add debug logging.

Also:

- Cleans up the code for handling cancelled requests in ExceptionHandlerMiddleware