### PR TITLE
Add halidom by default

### DIFF
--- a/DragaliaAPI.Database.Test/Repositories/FortRepositoryTest.cs
+++ b/DragaliaAPI.Database.Test/Repositories/FortRepositoryTest.cs
@@ -46,7 +46,7 @@ public class FortRepositoryTest : IClassFixture<DbTestFixture>
         await this.fixture.AddRangeToDatabase(
             new List<DbFortBuild>()
             {
-                new() { DeviceAccountId = "id", PlantId = FortPlants.TheHalidom, },
+                new() { DeviceAccountId = "id", PlantId = FortPlants.TheHungerdome, },
                 new() { DeviceAccountId = "id", PlantId = FortPlants.CircusTent, },
                 new() { DeviceAccountId = "id 2", PlantId = FortPlants.JackOLantern, },
                 new() { DeviceAccountId = "id 3", PlantId = FortPlants.WaterAltar, },
@@ -55,13 +55,14 @@ public class FortRepositoryTest : IClassFixture<DbTestFixture>
 
         (await this.fortRepository.GetBuilds("id").ToListAsync())
             .Should()
-            .BeEquivalentTo(
-                new List<DbFortBuild>()
-                {
-                    new() { DeviceAccountId = "id", PlantId = FortPlants.TheHalidom, },
-                    new() { DeviceAccountId = "id", PlantId = FortPlants.CircusTent },
-                },
-                opts => opts.Excluding(x => x.BuildId)
+            .AllSatisfy(x => x.DeviceAccountId.Should().Be("id"))
+            .And.ContainEquivalentOf(
+                new DbFortBuild() { DeviceAccountId = "id", PlantId = FortPlants.TheHungerdome, },
+                opts => opts.Excluding(x => x.Owner).Excluding(x => x.BuildId)
+            )
+            .And.ContainEquivalentOf(
+                new DbFortBuild() { DeviceAccountId = "id", PlantId = FortPlants.CircusTent },
+                opts => opts.Excluding(x => x.Owner).Excluding(x => x.BuildId)
             );
     }
 }

--- a/DragaliaAPI.Test/Integration/Dragalia/FortTest.cs
+++ b/DragaliaAPI.Test/Integration/Dragalia/FortTest.cs
@@ -18,7 +18,7 @@ public class FortTest : IntegrationTestBase
         this.fixture = fixture;
         this.client = fixture.CreateClient();
 
-        TestUtils.ApplyDateTimeAssertionOptions();
+        TestUtils.ApplyDateTimeAssertionOptions(thresholdSec: 2);
     }
 
     [Fact]
@@ -41,7 +41,7 @@ public class FortTest : IntegrationTestBase
                 PositionZ = 10,
                 BuildStartDate = start,
                 BuildEndDate = end,
-                IsNew = true,
+                IsNew = false,
                 LastIncomeDate = income, // Axe dojos don't make you money but let's pretend they do
             }
         );
@@ -54,23 +54,35 @@ public class FortTest : IntegrationTestBase
             )
         ).data.build_list
             .Should()
-            .BeEquivalentTo(
-                new List<BuildList>()
+            .ContainEquivalentOf(
+                new BuildList()
                 {
-                    new()
-                    {
-                        plant_id = FortPlants.AxeDojo,
-                        level = 10,
-                        position_x = 10,
-                        position_z = 10,
-                        build_start_date = start,
-                        build_end_date = end,
-                        fort_plant_detail_id = 10050410,
-                        build_status = FortBuildStatus.Construction,
-                        is_new = true,
-                        remain_time = end - DateTimeOffset.UtcNow,
-                        last_income_time = DateTimeOffset.UtcNow - income
-                    }
+                    plant_id = FortPlants.TheHalidom,
+                    level = 1,
+                    fort_plant_detail_id = 10010101,
+                    position_x = 16, // Default Halidom position
+                    position_z = 17,
+                    last_income_time = DateTime.UtcNow - DateTimeOffset.UnixEpoch,
+                    is_new = false,
+                    build_start_date = DateTimeOffset.UnixEpoch,
+                    build_end_date = DateTimeOffset.UnixEpoch,
+                },
+                opts => opts.Excluding(x => x.build_id)
+            )
+            .And.ContainEquivalentOf(
+                new BuildList()
+                {
+                    plant_id = FortPlants.AxeDojo,
+                    level = 10,
+                    position_x = 10,
+                    position_z = 10,
+                    build_start_date = start,
+                    build_end_date = end,
+                    fort_plant_detail_id = 10050410,
+                    build_status = FortBuildStatus.Construction,
+                    is_new = false,
+                    remain_time = end - DateTimeOffset.UtcNow,
+                    last_income_time = DateTimeOffset.UtcNow - income
                 },
                 opts => opts.Excluding(x => x.build_id)
             );

--- a/DragaliaAPI.Test/Integration/Other/DeleteSavefileTest.cs
+++ b/DragaliaAPI.Test/Integration/Other/DeleteSavefileTest.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net;
+using DragaliaAPI.Database.Entities;
 using DragaliaAPI.Models.Generated;
 using DragaliaAPI.Shared.Definitions.Enums;
 using FluentAssertions.Execution;
@@ -133,7 +134,10 @@ public class DeleteSavefileTest : IClassFixture<IntegrationTestFixture>
 
             storedSavefile.quest_story_list.Should().BeEmpty();
             storedSavefile.castle_story_list.Should().BeEmpty();
-            storedSavefile.build_list.Should().BeEmpty();
+            storedSavefile.build_list
+                .Should()
+                .ContainSingle()
+                .And.AllSatisfy(x => x.plant_id = FortPlants.TheHalidom);
         }
     }
 }

--- a/DragaliaAPI.Test/Unit/Services/UpdateDataServiceTest.cs
+++ b/DragaliaAPI.Test/Unit/Services/UpdateDataServiceTest.cs
@@ -121,11 +121,11 @@ public class UpdateDataServiceTest : IClassFixture<DbTestFixture>
             new()
             {
                 DeviceAccountId = deviceAccountId,
-                BuildId = 1,
+                BuildId = 4000,
                 Level = 2,
                 PositionX = 3,
                 PositionZ = 4,
-                PlantId = FortPlants.AbyssalBell,
+                PlantId = FortPlants.IronWeatherVane,
                 IsNew = true,
                 LastIncomeDate = DateTimeOffset.FromUnixTimeSeconds(5),
                 BuildStartDate = DateTimeOffset.FromUnixTimeSeconds(10),

--- a/DragaliaAPI/Pages/News.cshtml
+++ b/DragaliaAPI/Pages/News.cshtml
@@ -27,7 +27,7 @@
 
 	<p>The server owner can be contacted via Discord at <code>dreadfullydistinct#1458</code>. Alternatively, this server and others can be discussed in the <a href="https://discord.gg/j9zSttjjWj">Dragalia Lost Reverse Engineering Discord server</a>.</p>
 	
-	<p>The database may be wiped without warning and any progress removed, so please try not to get too attached to progress you make on this server.</p>
+	<p><b>The database may be wiped without warning and any progress removed, so please try not to get too attached to progress you make on this server.</b> If you want to gain access to specific characters, rather than wasting time summoning, please use the <a href="https://github.com/sockperson/DragaliaSaveEditor/releases/latest">save editor</a> developed by <code>sockperson#8317</code>.</p>
 
 	<h2>What should work</h2>
 	<ul>

--- a/DragaliaAPI/Services/SavefileService.cs
+++ b/DragaliaAPI/Services/SavefileService.cs
@@ -429,6 +429,19 @@ public class SavefileService : ISavefileService
         await this.AddDefaultParties(deviceAccountId);
         await this.AddDefaultCharacters(deviceAccountId);
 
+        // This needs to be in the save or the halidom screen will softlock
+        // TODO: Move this to the tutorial step which gives you access to the Halidom,
+        // so that saves imported without it will also avoid the softlock
+        await apiContext.PlayerFortBuilds.AddAsync(
+            new DbFortBuild()
+            {
+                DeviceAccountId = deviceAccountId,
+                PlantId = FortPlants.TheHalidom,
+                PositionX = 16, // Default Halidom position
+                PositionZ = 17,
+            }
+        );
+
         await this.apiContext.SaveChangesAsync();
     }
 


### PR DESCRIPTION
Closes #118 

Need to update this whenever the tutorial can be naturally progressed to unlocking Halidom to add it there. Current implementation will not address the issue of importing a save without a halidom (which they don't until you complete that part of the tutorial)