### PR TITLE
Fix duplicate weapon skin bug

### DIFF
--- a/DragaliaAPI.Database.Test/Repositories/WeaponRepositoryTest.cs
+++ b/DragaliaAPI.Database.Test/Repositories/WeaponRepositoryTest.cs
@@ -182,4 +182,19 @@ public class WeaponRepositoryTest : IClassFixture<DbTestFixture>
                 }
             );
     }
+
+    [Fact]
+    public async Task AddSkin_DuplicateSkins_NoPkException()
+    {
+        await this.weaponRepository.AddSkin(6);
+        await this.fixture.ApiContext.SaveChangesAsync();
+
+        Func<Task> act = async () =>
+        {
+            await this.weaponRepository.AddSkin(6);
+            await this.fixture.ApiContext.SaveChangesAsync();
+        };
+
+        await act.Invoking(x => x.Invoke()).Should().NotThrowAsync();
+    }
 }

--- a/DragaliaAPI.Database/Repositories/InventoryRepository.cs
+++ b/DragaliaAPI.Database/Repositories/InventoryRepository.cs
@@ -73,8 +73,6 @@ public class InventoryRepository : IInventoryRepository
         if (item == Materials.Empty)
             return;
 
-        this.logger.LogDebug("Updating material id {mat} by quantity {q}", item, quantity);
-
         DbPlayerMaterial material = await this.FindAsync(item);
 
         if (material.Quantity + quantity < 0)
@@ -122,9 +120,14 @@ public class InventoryRepository : IInventoryRepository
     {
         foreach (Materials m in list)
         {
-            // Db query (find) in loop??? Any way to do this better???
             await this.UpdateQuantity(deviceAccountId, m, quantity);
         }
+
+        this.logger.LogDebug(
+            "Updated list of materials by quantity {quantity}: {list}",
+            quantity,
+            list
+        );
     }
 
     public async Task UpdateQuantity(IEnumerable<KeyValuePair<Materials, int>> quantityMap)
@@ -133,6 +136,8 @@ public class InventoryRepository : IInventoryRepository
         {
             await this.UpdateQuantity(mat, quantity);
         }
+
+        this.logger.LogDebug("Updated player materials by map {@map}", quantityMap);
     }
 
     public async Task<DbPlayerMaterial?> GetMaterial(string deviceAccountId, Materials materialId)

--- a/DragaliaAPI.Database/Repositories/UserDataRepository.cs
+++ b/DragaliaAPI.Database/Repositories/UserDataRepository.cs
@@ -117,6 +117,8 @@ public class UserDataRepository : BaseRepository, IUserDataRepository
     public async Task UpdateCoin(string deviceAccountId, long offset)
     {
         this.logger.LogDebug("Updating player rupies by {offset}", offset);
+        if (offset == 0)
+            return;
 
         DbPlayerUserData userData = await this.LookupUserData(deviceAccountId);
 

--- a/DragaliaAPI.Database/Repositories/WeaponRepository.cs
+++ b/DragaliaAPI.Database/Repositories/WeaponRepository.cs
@@ -57,6 +57,18 @@ public class WeaponRepository : IWeaponRepository
     {
         this.logger.LogDebug("Adding weapon skin {skin}", weaponSkinId);
 
+        if (
+            await this.apiContext.PlayerWeaponSkins.FindAsync(
+                this.playerDetailsService.AccountId,
+                weaponSkinId
+            )
+            is not null
+        )
+        {
+            this.logger.LogDebug("Weapon skin was already owned.");
+            return;
+        }
+
         await this.apiContext.PlayerWeaponSkins.AddAsync(
             new DbWeaponSkin()
             {

--- a/DragaliaAPI.Test/Unit/Services/DungeonServiceTest.cs
+++ b/DragaliaAPI.Test/Unit/Services/DungeonServiceTest.cs
@@ -50,27 +50,4 @@ public class DungeonServiceTest
 
         (await this.dungeonService.GetDungeon(key)).Should().BeEquivalentTo(session);
     }
-
-    [Fact]
-    public async Task StartDungeon_Delete_CannotGetAfterwards()
-    {
-        DungeonSession session =
-            new()
-            {
-                QuestData = MasterAsset.QuestData.Get(100230302),
-                Party = new List<PartySettingList>()
-                {
-                    new() { chara_id = Shared.Definitions.Enums.Charas.Botan }
-                }
-            };
-
-        string key = await this.dungeonService.StartDungeon(session);
-
-        (await this.dungeonService.FinishDungeon(key)).Should().BeEquivalentTo(session);
-
-        await this.dungeonService
-            .Invoking(x => x.GetDungeon(key))
-            .Should()
-            .ThrowAsync<DungeonException>();
-    }
 }

--- a/DragaliaAPI/Services/DungeonService.cs
+++ b/DragaliaAPI/Services/DungeonService.cs
@@ -54,7 +54,8 @@ public class DungeonService : IDungeonService
     {
         DungeonSession session = await this.GetDungeon(dungeonKey);
 
-        await cache.RemoveAsync(Schema.DungeonKey_DungeonData(dungeonKey));
+        // Don't remove in case the client re-calls due to timeout
+        // await cache.RemoveAsync(Schema.DungeonKey_DungeonData(dungeonKey));
 
         return session;
     }

--- a/DragaliaAPI/Services/WeaponService.cs
+++ b/DragaliaAPI/Services/WeaponService.cs
@@ -119,7 +119,7 @@ public class WeaponService : IWeaponService
     )
     {
         LogContext.PushProperty("WeaponBodyId", body.Id);
-        LogContext.PushProperty("BuildupRequest", buildup);
+        LogContext.PushProperty("BuildupRequest", buildup, destructureObjects: true);
 
         return buildup.buildup_piece_type switch
         {


### PR DESCRIPTION
- Checks if a weapon skin is owned before adding it, due to the possibility of the save editor adding all skins but not all weapons
- Possibly fixes a random bug that sometimes happens with dungeon keys not being found
- Logging adjustments