### PR TITLE
Properly unlock shared skills for story characters

### DIFF
--- a/DragaliaAPI.Database/Entities/DbPlayerCharaData.cs
+++ b/DragaliaAPI.Database/Entities/DbPlayerCharaData.cs
@@ -170,5 +170,6 @@ public class DbPlayerCharaData : IDbHasAccountId
         this.Ability1Level = (byte)data.DefaultAbility1Level;
         this.Ability2Level = (byte)data.DefaultAbility2Level;
         this.Ability3Level = (byte)data.DefaultAbility3Level;
+        this.IsUnlockEditSkill = data.Availability == CharaAvailabilities.Story;
     }
 }

--- a/DragaliaAPI/Controllers/Dragalia/LoginController.cs
+++ b/DragaliaAPI/Controllers/Dragalia/LoginController.cs
@@ -11,6 +11,14 @@ namespace DragaliaAPI.Controllers.Dragalia;
 public class LoginController : DragaliaControllerBase
 {
     [HttpPost]
+    public IActionResult Login()
+    {
+        // These fucking webcrawlers keep calling /login
+        // and ASP.NET throws a 500 because of ambiguous route
+        return this.NotFound();
+    }
+
+    [HttpPost]
     [Route("index")]
     public DragaliaResult Index()
     {


### PR DESCRIPTION
Also fixes a 500 when webcrawlers call /login due to ambiguous route -- defines it explicitly as a 404 endpoint. In practice it will always return 400 as the caller will fail SessionAuthentication