### PR TITLE
Dragon sell income fix

### DIFF
--- a/DragaliaAPI.Test/Unit/Services/DragonServiceTest.cs
+++ b/DragaliaAPI.Test/Unit/Services/DragonServiceTest.cs
@@ -36,7 +36,8 @@ public class DragonServiceTest
             mockUnitRepository.Object,
             mockInventoryRepository.Object,
             mockUpdateDataService.Object,
-            mockStoryRepository.Object
+            mockStoryRepository.Object,
+            LoggerTestUtils.Create<DragonService>()
         );
     }
 


### PR DESCRIPTION
Fixes:
- dragon sell income calculated incorrectly when selling more than 1 dragon of the same type
- dragon sell income calculated incorrectly when selling unbound dragons