### PR TITLE
Potential summon fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,10 @@
 .run
 .env
 test_coverage.json
-*/**/launchSettings.json
-*/**/appsettings.Development.json
+launchSettings.json
+appsettings.Development.json
+test_coverage.json
+.run
 
 # CMake
 cmake-build-*/

--- a/DragaliaAPI/Controllers/Dragalia/SummonController.cs
+++ b/DragaliaAPI/Controllers/Dragalia/SummonController.cs
@@ -389,11 +389,10 @@ public class SummonController : DragaliaControllerBase
             let rarity = summonResult
                 .First(x => x.entity_type == EntityTypes.Dragon && (Dragons)x.id == dragon.id)
                 .rarity
-            let dewPoint = dragon.isNew ? 0 : DewValueData.DupeSummon[rarity]
             select new AtgenResultUnitList
             {
                 id = (int)dragon.id,
-                dew_point = dewPoint,
+                dew_point = 0,
                 entity_type = EntityTypes.Dragon,
                 is_new = dragon.isNew,
                 rarity = rarity
@@ -491,8 +490,8 @@ public class SummonController : DragaliaControllerBase
                 new EntityResult()
                 {
                     new_get_entity_list = charaRewardList
-                        .Concat(dragonRewardList)
                         .Where(x => x.is_new)
+                        .Concat(dragonRewardList)
                         .Select(
                             x =>
                                 new AtgenDuplicateEntityList()


### PR DESCRIPTION
Turns out we were not sending dragons in `new_get_entity_list` unless their `is_new` was `true`, i.e. they had been obtained for the first time. This is not the correct behaviour because you can receive new dragons that are duplicates of existing owned ones.

Additionally, we were rewarding eldwater for dragons which does not make any sense either.

Potentially closes #90 